### PR TITLE
adapts i18n to changed core

### DIFF
--- a/app/views/cost_objects/_form.html.erb
+++ b/app/views/cost_objects/_form.html.erb
@@ -34,10 +34,10 @@
   <legend><%= l(:caption_material_budget) %></legend>
   <table class="list material_budget_items" id="material_budget_items">
     <thead><tr>
-      <th class="cost_units"><%= l(:caption_cost_unit_plural)%></th>
-      <th><%= l(:caption_cost_type) %></th>
-      <th><%= l(:label_comment) %></th>
-      <% if User.current.allowed_to?(:view_cost_rates, @project)%><th class="currency" id="material_budget_items_price"><%= l(:caption_budget) %></th><%end%>
+      <th class="cost_units"><%= MaterialBudgetItem.human_attribute_name(:units) %></th>
+      <th><%= MaterialBudgetItem.human_attribute_name(:cost_type) %></th>
+      <th><%= MaterialBudgetItem.human_attribute_name(:comment) %></th>
+      <% if User.current.allowed_to?(:view_cost_rates, @project)%><th class="currency" id="material_budget_items_price"><%= MaterialBudgetItem.human_attribute_name(:budget) %></th><%end%>
       <th></th>
     </tr></thead>
     <tbody id="material_budget_items_body">
@@ -53,11 +53,11 @@
   <legend><%= l(:caption_labor_budget) %></legend>
   <table class="list labor_budget_items" id="labor_budget_items">
     <thead><tr>
-      <th class="cost_units"><%= l(:field_hours)%></th>
-      <th><%= l(:label_user) %></th>
-      <th><%= l(:label_comment) %></th>
+      <th class="cost_units"><%= LaborBudgetItem.human_attribute_name(:hours) %></th>
+      <th><%= LaborBudgetItem.human_attribute_name(:user) %></th>
+      <th><%= LaborBudgetItem.human_attribute_name(:comment) %></th>
       <% if User.current.allowed_to?(:view_hourly_rates, @project) %>
-        <th class="currency" id="labor_budget_items_price"><%= l(:caption_budget) %></th>
+        <th class="currency" id="labor_budget_items_price"><%= LaborBudgetItem.human_attribute_name(:budget) %></th>
       <% end %>
       <th></th>
     </tr></thead>

--- a/app/views/cost_objects/_list.html.erb
+++ b/app/views/cost_objects/_list.html.erb
@@ -6,12 +6,12 @@
                                                        :title => "#{l(:button_check_all)}/#{l(:button_uncheck_all)}" %>
     </th>
     <%= sort_header_tag("id", :caption => '#', :default_order => 'desc') %>
-    <%= sort_header_tag("status", :caption => l(:caption_status), :default_order => 'desc') %>
-    <%= sort_header_tag("subject", :caption => l(:caption_subject)) %>
-    <th class="currency"><%= l(:caption_budget) %></th>
-    <th class="currency"><%= l(:caption_spent) %></th>
-    <th class="currency"><%= l(:caption_budget_available) %></th>
-    <th><%= l(:caption_budget_ratio) %></th>
+    <%= sort_header_tag("status", :caption => CostObject.human_attribute_name(:status), :default_order => 'desc') %>
+    <%= sort_header_tag("subject", :caption => CostObject.human_attribute_name(:subject)) %>
+    <th class="currency"><%= CostObject.human_attribute_name(:budget) %></th>
+    <th class="currency"><%= CostObject.human_attribute_name(:spent) %></th>
+    <th class="currency"><%= CostObject.human_attribute_name(:available) %></th>
+    <th><%= CostObject.human_attribute_name(:budget_ratio) %></th>
   </tr></thead>
   <tbody>
     <% total_budget = BigDecimal.new("0"); labor_budget = BigDecimal.new("0"); material_budget = BigDecimal.new("0"); spent = BigDecimal.new("0") %>

--- a/app/views/cost_objects/_show_variable_cost_object.html.erb
+++ b/app/views/cost_objects/_show_variable_cost_object.html.erb
@@ -4,10 +4,10 @@
   <h4><%= l(:caption_material_budget)%></h4>
   <table class="material_budget_items list">
     <thead><tr>
-      <th><%= l(:caption_cost_unit_plural)%></th>
-      <th><%= l(:caption_cost_type) %></th>
-      <th><%= l(:caption_comment) %></th>
-      <th class="currency"><%= l(:caption_budget) %></th>
+      <th><%= MaterialBudgetItem.human_attribute_name(:units) %></th>
+      <th><%= MaterialBudgetItem.human_attribute_name(:cost_type) %></th>
+      <th><%= MaterialBudgetItem.human_attribute_name(:comment) %></th>
+      <th class="currency"><%= MaterialBudgetItem.human_attribute_name(:budget) %></th>
     </tr></thead>
     <tbody>
       <% @cost_object.material_budget_items.each do |material_budget_item| %>
@@ -28,10 +28,10 @@
   <h4><%= l(:caption_material_costs) %></h4>
   <table class="material_budget_items list">
     <thead><tr>
-      <th><%= l(:caption_issue)%></th>
-      <th><%= l(:caption_cost_unit_plural) %></th>
-      <th><%= l(:caption_cost_type) %></th>
-      <th class="currency"><%= l(:caption_costs) %></th>
+      <th><%= CostEntry.human_attribute_name(:issue)%></th>
+      <th><%= CostEntry.human_attribute_name(:units) %></th>
+      <th><%= CostEntry.human_attribute_name(:cost_type) %></th>
+      <th class="currency"><%= CostEntry.human_attribute_name(:costs) %></th>
     </tr></thead>
     <tbody>
       <% @cost_object.cost_entries.visible(User.current, @project).all(:include => [:cost_type]).group_by(&:issue).each do |issue, cost_entries|
@@ -71,10 +71,10 @@
   <h4><%= l(:caption_labor_budget)%></h4>
   <table class="labor_budget_items list">
     <thead><tr>
-      <th><%= l(:field_hours)%></th>
-      <th><%= l(:label_user) %></th>
-      <th><%= l(:caption_comment) %></th>
-      <th class="currency"><%= l(:caption_budget) %></th>
+      <th><%= LaborBudgetItem.human_attribute_name(:hours) %></th>
+      <th><%= LaborBudgetItem.human_attribute_name(:user) %></th>
+      <th><%= LaborBudgetItem.human_attribute_name(:comment) %></th>
+      <th class="currency"><%= LaborBudgetItem.human_attribute_name(:budget) %></th>
     </tr></thead>
     <tbody>
       <% @cost_object.labor_budget_items.each do |labor_budget_item| %>
@@ -103,10 +103,10 @@
   <h4><%= l(:caption_labor_costs) %></h4>
   <table class="labor_budget_items list">
     <thead><tr>
-      <th><%= l(:caption_issue)%></th>
-      <th><%= l(:field_hours)%></th>
-      <th><%= l(:label_user) %></th>
-      <th class="currency"><%= l(:caption_costs) %></th>
+      <th><%= TimeEntry.human_attribute_name(:issue) %></th>
+      <th><%= TimeEntry.human_attribute_name(:hours) %></th>
+      <th><%= TimeEntry.human_attribute_name(:user) %></th>
+      <th class="currency"><%= TimeEntry.human_attribute_name(:costs) %></th>
     </tr></thead>
     <tbody>
     <% @cost_object.time_entries.visible(User.current, @project).all.group_by(&:issue).each do |issue, time_entries|

--- a/app/views/cost_objects/show.html.erb
+++ b/app/views/cost_objects/show.html.erb
@@ -16,23 +16,23 @@
 
   <table width="100%">
     <tr>
-      <td style="width:15%" class="type"><strong><%=l(:field_type)%>:</strong></td>
+      <td style="width:15%" class="type"><strong><%= CostObject.human_attribute_name(:type) %>:</strong></td>
       <td style="width:35%" class="type"><%= @cost_object.type_label %></td>
 
-      <td style="width:15%" class="due-date"><strong><%=l(:field_fixed_date)%>:</strong></td>
+      <td style="width:15%" class="due-date"><strong><%= CostObject.human_attribute_name(:fixed_date) %>:</strong></td>
       <td style="width:35%"><%= format_date(@cost_object.fixed_date) %></td>
     </tr>
 
     <tr>
-      <td class="status"><strong><%=l(:field_status)%>:</strong></td>
+      <td class="status"><strong><%= CostObject.human_attribute_name(:status)%>:</strong></td>
       <td class="status"><%= l(@cost_object.status) %></td>
 
-      <td class="progress"><strong><%=l(:field_budget_ratio)%>:</strong></td>
+      <td class="progress"><strong><%= CostObject.human_attribute_name(:budget_ratio) %>:</strong></td>
       <td class="progress"><%= extended_progress_bar(@cost_object.budget_ratio, :width => '80px', :legend => "#{@cost_object.budget_ratio}%") %></td>
     </tr>
   </table>
 
-  <p><strong><%=l(:field_description)%></strong></p>
+  <p><strong><%= CostObject.human_attribute_name(:description) %></strong></p>
   <div class="wiki">
     <%= textilizable @cost_object, :description, :attachments => @cost_object.attachments %>
   </div>

--- a/app/views/cost_reports/_list_items.html.erb
+++ b/app/views/cost_reports/_list_items.html.erb
@@ -1,3 +1,5 @@
+<%# Todo: This looks like it should be moved into openproject_reporting %>
+
 <% if @entries.blank? %>
   <p class="nodata"><%= l(:label_no_data) %></p>
 <% else %>

--- a/app/views/costlog/edit.html.erb
+++ b/app/views/costlog/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => 'shared/costs_header' %>
-<h2><%= l(:label_spent_costs) %></h2>
+<h2><%= l(:label_log_costs) %></h2>
 
 <% url = @cost_entry.new_record? ?
           { :action => 'create', :project_id => @project.id } :
@@ -30,7 +30,7 @@
         <%= observe_field( "cost_entry_spent_on", :frequency => 1, :url => {:controller => :cost_objects, :action => :update_material_budget_item, :project_id => @cost_entry.project}, :with => "'cost_type_id=' + encodeURIComponent(document.getElementById('cost_entry_cost_type_id').value) + '&units=' + encodeURIComponent(document.getElementById('cost_entry_units').value) + '&fixed_date=' + encodeURIComponent(value) + '&element_id=cost_entry'") %>
   </p>
     <p>
-      <label for="cost_entry_costs_edit"><%= l(:field_costs) %></label>
+      <label for="cost_entry_costs_edit"><%= CostEntry.human_attribute_name(:costs) %></label>
       <% if User.current.allowed_to? :view_cost_rates, @cost_entry.project %>
         <a href="javascript:;" id="cost_entry_costs" class="icon icon-edit" title="<%= l(:help_click_to_edit) %>">
           <%= number_to_currency(@cost_entry.calculated_costs) %>

--- a/app/views/hourly_rates/_list_default.html.erb
+++ b/app/views/hourly_rates/_list_default.html.erb
@@ -1,15 +1,15 @@
 <div class="contextual">
 <%= link_to l(:button_update), {:controller => 'hourly_rates', :action => 'edit', :id => @user}, :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
 </div>
-<h3><%= l(:caption_default_rates) %></h3>
+<h3><%= User.human_attribute_name(:default_rates) %></h3>
 <% if @rates_default.blank? %>
 <p class="nodata"><%= l(:label_no_data) %></p>
 <% else %>
 <table class="list rates">
   <thead><tr>
-    <th><%= l(:label_valid_from) %></th>
-    <th class="currency"><%= l(:label_rate) %></th>
-    <th><%= l(:caption_current_rate) %></th>
+    <th><%= Rate.human_attribute_name(:valid_from) %></th>
+    <th class="currency"><%= Rate.model_name.human %></th>
+    <th><%= User.human_attribute_name(:current_rate) %></th>
   </tr></thead>
   <tbody id="rates_body">
   <% current_rate = @user.current_default_rate() %>

--- a/app/views/hourly_rates/_list_project.html.erb
+++ b/app/views/hourly_rates/_list_project.html.erb
@@ -16,9 +16,9 @@
 <% else %>
 <table class="list rates">
   <thead><tr>
-    <th><%= l(:label_valid_from) %></th>
-    <th class="currency"><%= l(:label_rate) %></th>
-    <th><%= l(:caption_current_rate) %></th>
+    <th><%= Rate.human_attribute_name(:valid_from) %></th>
+    <th class="currency"><%= Rate.model_name.human %></th>
+    <th><%= User.human_attribute_name(:current_rate) %></th>
   </tr></thead>
   <tbody id="rates_body">
   <% current_rate = @user.current_rate(project, false) %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,8 +1,51 @@
 ---
 de:
+  attributes:
+    units: Einheiten
+    hours: Stunden
+    budget: Geplante Kosten
+    comment: Kommentar
+    costs: Kosten
+    valid_from: Gültig ab
+
+  activerecord:
+    models:
+      cost_object: Budget
+      rate: Satz
+    attributes:
+      cost_object:
+        type: Kostenart
+        budget_ratio: Verbraucht (Prozent)
+        project_manager_signoff: Genehmigt vom Projektmanager
+        client_signoff: Genehmigt vom Kunden
+        fixed_date: Referenzdatum
+        planned: Geplant
+        spent: Verbraucht
+        available: Verfügbar
+      cost_type:
+        unit: Einheit
+        unit_plural: Einheit plural
+      cost_entry:
+        cost_type: Kostenart
+        issue: Ticket
+        spent_on: Datum
+      material_budget_item:
+        cost_type: Kostenart
+      issue:
+        cost_object: Budget
+        spent_units: Gebuchte Einheiten
+        spent_costs: Gebuchte Kosten
+        spent_hours: Gebuchte Stunden
+        material_costs: Stückkosten
+        overall_costs: Gesamtkosten
+        labor_costs: Personaleinzelkosten
+        cost_object_subject: Budgettitel
+      user:
+        current_rate: Aktueller Satz
+        default_rates: Standardsätze
+
   cost_objects_title: Budgets
   cost_types_title: Kostenarten
-  cost_reports_title: Reports
   project_module_costs_module: Controlling
 
   currency_separator: ","
@@ -15,30 +58,23 @@ de:
   week: Woche
   group_by_others: In keiner der Gruppen
 
-  button_add_budget_item: "Budgetposition hinzuf\xC3\xBCgen"
+  button_add_budget_item: "Budgetposition hinzufügen"
   button_add_cost_object: Neues Budget anlegen
   button_add_cost_type: Kostenart anlegen
-  button_add_rate: "Satz hinzuf\xC3\xBCgen"
+  button_add_rate: "Satz hinzufügen"
   button_log_costs: "Stückkosten buchen"
   button_log_time: "Zeit buchen"
 
   caption_booked_on_project: "Auf das Projekt gebucht"
-  caption_budget: Budget
-  caption_budget_available: Verfügbares Budget
-  caption_budget_ratio: Verbrauchtes Budget
-  caption_comment: Kommentar
   caption_cost_type: Kostenart
   caption_cost_type_plural: Kostenarten
   caption_cost_type_unit_name: Einheit
   caption_cost_type_unit_name_plural: Einheit Plural
   caption_cost_unit_plural: Einheiten
-  caption_costs: Kosten
   caption_current_rate: Aktueller Satz
   caption_default: Standard
-  field_rate: Satz
-  field_rates: Sätze
-  caption_default_rate_history_for: "Standardsatz-Historie f\xC3\xBCr %{user}"
-  caption_default_rates: "Standards\xC3\xA4tze"
+  caption_default_rate_history_for: "Standardsatz-Historie für %{user}"
+  caption_default_rates: "Standardsätze"
   caption_fixed_date: Referenzdatum
   caption_issue: Ticket
   caption_labor: Personal
@@ -51,50 +87,27 @@ de:
   caption_progress: Fortschritt
   caption_rate: Satz
   caption_rate_history: Stundensatz-Historie
-  caption_rate_history_for: "Stundensatz-Historie f\xC3\xBCr %{user}"
-  caption_rate_history_for_project: "Studensatz-Historie f\xC3\xBCr %{user} in Projekt %{project}"
+  caption_rate_history_for: "Stundensatz-Historie für %{user}"
+  caption_rate_history_for_project: "Studensatz-Historie für %{user} in Projekt %{project}"
   caption_set_rate: Aktuellen Satz festlegen
   caption_spent: Gebucht
   caption_status: Status
   caption_subject: Titel
-  caption_valid_from: "G\xC3\xBCltig ab"
-  field_valid_from: "G\xC3\xBCltig ab"
+  caption_valid_from: "Gültig ab"
 
   error_generic: "Bei der Anfrage ist ein Fehler aufgetreten. Sie wurde zurückgesetzt. Bitte melden Sie das Problem Ihrem Redmine Administrator"
 
-  field_budget_ratio: Verbrauchtes Budget
-  field_client_signoff: Genehmigt vom Kunden
-  field_cost_object: Budget
-  field_cost_object_subject: Budgettitel
-  field_cost_type: Kostenart
-  field_costs: Kosten
-  field_default: Standard
-  field_deliverable: Budget
-  field_fixed_date: Referenzdatum
-  field_kind: Typ
-  field_labor_budget: Geplante Personaleinzelkosten
-  field_labor_costs: Personaleinzelkosten
-  field_material_budget: Geplante Stückkosten
-  field_material_costs: Stückkosten
-  field_overall_costs: Gesamtkosten
-  field_overridden_costs: "\xC3\x9Cberschriebene Kosten"
-  field_project_manager_signoff: Genehmigt vom Projektmanager
-  field_spent: Gebucht
-  field_unit: Einheit
-  field_unit_plural: Einheit Plural
-  field_unit_price: Stückeinzelpreis
-  field_units: Einheiten
 
   help_click_to_edit: Hier Klicken zum bearbeiten.
-  help_currency_format: "Format der angezeigten W\xC3\xA4hrungswerte. %n wird mit dem Zahlenwert ersetzt, %u mit der W\xC3\xA4hrung."
-  help_override_rate: "Hier einen Wert eingeben um den Standardwert zu \xC3\xBCberschreiben."
+  help_currency_format: "Format der angezeigten Währungswerte. %n wird mit dem Zahlenwert ersetzt, %u mit der Währung."
+  help_override_rate: "Hier einen Wert eingeben um den Standardwert zu Überschreiben."
 
-  label_costlog: Stückkosten buchen
+  label_log_costs: Stückkosten buchen
   label_awaiting_client: Warten auf Kundenantwort
   label_status_awaiting_client: Warten auf Kundenantwort
   label_awaiting_manager: Warten auf Managerantwort
   label_between: zwischen
-  label_cost_filter_add: "Kostenfilter hinzuf\xC3\xBCgen"
+  label_cost_filter_add: "Kostenfilter hinzufügen"
   label_cost_object: Budget
   label_cost_object_id: "Budget #%{id}"
   label_cost_object_new: Neues Budget
@@ -102,11 +115,11 @@ de:
   label_cost_plural: Kosten
   label_cost_report: Report
   label_costs_per_page: Kosten dieser Seite
-  label_currency: "W\xC3\xA4hrung"
-  label_currency_format: "W\xC3\xA4hrungsformat"
+  label_currency: "Währung"
+  label_currency_format: "Währungsformat"
   label_current_default_rate: Aktueller Standardsatz
   label_date_on: am
-  label_deleted_cost_types: "Gel\xC3\xB6schte Kostenarten"
+  label_deleted_cost_types: "Gelöschte Kostenarten"
   label_deliverable: Budget
   label_display_cost_entries: Stückkosten anzeigen
   label_display_time_entries: Personaleinzelkosten anzeigen
@@ -117,9 +130,9 @@ de:
   label_generic_user: Generischer Benutzer
   label_greater_or_equal: ">="
   label_group_by: Gruppiere Ergebnisse
-  label_group_by_add: "Gruppierungsfeld hinzuf\xC3\xBCgen"
-  label_include_deleted: "Gel\xC3\xB6schte anzeigen"
-  label_issue_filter_add: "Ticketfilter hinzuf\xC3\xBCgen"
+  label_group_by_add: "Gruppierungsfeld hinzufügen"
+  label_include_deleted: "Gelöschte anzeigen"
+  label_issue_filter_add: "Ticketfilter hinzufügen"
   label_kind: Art
   label_less_or_equal: <=
   label_no: Nein
@@ -127,13 +140,11 @@ de:
   label_overall_costs: Gesamtkosten
   label_rate: Satz
   label_rate_plural: Sätze
-  label_spent_costs: Gebuchte Kosten
-  label_spent_units: Gebuchte Einheiten
   label_status_finished: Abgeschlossen
   label_status_in_progress: In  Bearbeitung
   label_units: Einheiten
   label_until: bis
-  label_valid_from: "G\xC3\xBCltig ab"
+  label_valid_from: "Gültig ab"
   label_variable_cost_object: Variables Budget
   label_view_all_cost_objects: "Alle Budgets anzeigen"
   label_yes: Ja
@@ -148,17 +159,17 @@ de:
   permission_edit_cost_entries: Bearbeiten gebuchter Stückkosten
   permission_edit_cost_objects: "Budgets bearbeiten"
   permission_edit_own_cost_entries: Bearbeiten eigener gebuchter Stückkosten
-  permission_edit_rates: "Stundens\xC3\xA4tze editieren"
+  permission_edit_rates: "Stundensätze editieren"
   permission_log_costs: Stückkosten buchen
   permission_log_own_costs: Eigene Stückkosten buchen
   permission_view_cost_entries: Gebuchte Kosten ansehen
   permission_view_cost_objects: "Budgets ansehen"
   permission_view_cost_rates: Anzeigen von Stückpreisen
-  permission_view_hourly_rates: "Alle Stundens\xC3\xA4tze ansehen"
-  permission_view_own_hourly_rate: "Eigene Stundens\xC3\xA4tze ansehen"
+  permission_view_hourly_rates: "Alle Stundensätze ansehen"
+  permission_view_own_hourly_rate: "Eigene Stundensätze ansehen"
 
   text_assign_time_and_cost_entries_to_project: Gebuchte Aufwände dem Projekt zuweisen
-  text_cost_object_change_type_confirmation: "Sind Sie sicher? Diese Operation wird einige Informationen des aktuellen Budgets l\xC3\xB6schen."
+  text_cost_object_change_type_confirmation: "Sind Sie sicher? Diese Operation wird einige Informationen des aktuellen Budgets löschen."
   text_destroy_cost_entries_question: Es wurden bereits %{cost_entries} auf dieses Ticket gebucht. Was soll mit den Aufwänden geschehen?
   text_destroy_time_and_cost_entries:  Gebuchte Aufwände löschen
   text_destroy_time_and_cost_entries_question: Es wurden bereits %{hours} Stunden sowie %{cost_entries} auf dieses Ticket gebucht. Was soll mit den Aufwänden geschehen?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,8 +1,51 @@
 ---
 en:
+  attributes:
+    units: Units
+    hours: Hours
+    budget: Planned costs
+    comment: Comment
+    costs: Costs
+    valid_from: Valid from
+
+  activerecord:
+    models:
+      cost_object: Budget
+      rate: Rate
+    attributes:
+      cost_object:
+        type: Cost type
+        budget_ratio: Spent (ratio)
+        project_manager_signoff: Project manager signoff
+        client_signoff: Client signoff
+        fixed_date: Fixed date
+        budget: Planned
+        spent: Spent
+        available: Available
+      cost_type:
+        unit: Unit name
+        unit_plural: Pluralized unit name
+      cost_entry:
+        cost_type: Cost type
+        issue: Issue
+        spent_on: Date
+      material_budget_item:
+        cost_type: Cost type
+      issue:
+        cost_object: Budget
+        spent_units: Spent units
+        spent_costs: Spent costs
+        spent_hours: Spent hours
+        material_costs: Unit costs
+        overall_costs: Overall costs
+        labor_costs: Labor costs
+        cost_object_subject: Budget title
+      user:
+        current_rate: Current rate
+        default_rates: Default rates
+
   cost_objects_title: Budgets
   cost_types_title: Cost Types
-  cost_reports_title: Cost Reports
   project_module_costs_module: Cost Control
 
   currency_separator: .
@@ -22,20 +65,13 @@ en:
   button_log_costs: Log unit costs
 
   caption_booked_on_project: "Booked on Project"
-  caption_budget: Planned Costs
-  caption_budget_available: Remaining Budget
-  caption_budget_ratio: Spent Budget
-  caption_comment: Comment
   caption_cost_type: Cost Type
   caption_cost_type_plural: Cost Types
   caption_cost_type_unit_name: Unit Name
   caption_cost_type_unit_name_plural: Pluralized Unit Name
   caption_cost_unit_plural: Units
-  caption_costs: Costs
   caption_current_rate: Current Rate
   caption_default: Default
-  field_rate: Rate
-  field_rates: Rates
   caption_default_rate_history_for: Default Rate History for %{user}
   caption_default_rates: Default Rates
   caption_fixed_date: Fixed Date
@@ -57,40 +93,15 @@ en:
   caption_status: Status
   caption_subject: Title
   caption_valid_from: Valid from
-  field_valid_from: Valid from
 
   error_generic: "An error occurred while executing the query. It has been resetted. Please report this error to your Redmine administrator."
 
-  field_budget_ratio: Spent Budget
-  field_client_signoff: Client signoff
-  field_cost_object: Budget
-  field_cost_object_subject: Budget Title
-  field_cost_type: Cost type
-  field_costs: Costs
-  field_default: Default
-  field_deliverable: Budget
-  label_display_cost_entries: Display unit costs
-  label_display_time_entries: Display reported hours
-  field_fixed_date: Fixed Date
-  field_kind: Type
-  field_labor_budget: Planned Labor Costs
-  field_labor_costs: Labor Costs
-  field_material_budget: Planned Unit Costs
-  field_material_costs: Unit Costs
-  field_overall_costs: Overall costs
-  field_overridden_costs: Overridden Costs
-  field_project_manager_signoff: Project manager signoff
-  field_spent: Spent
-  field_unit: Unit name
-  field_unit_plural: Pluralized unit name
-  field_unit_price: Unit price
-  field_units: Units
 
   help_click_to_edit: Click here to edit.
   help_currency_format: Format of displayed currency values. %n is replaced with the currency value, %u ist replaced with the currency unit.
   help_override_rate: Enter a value here to override the default rate.
 
-  label_costlog: Log unit costs
+  label_log_costs: Log unit costs
   label_awaiting_client: Awaiting client response
   label_status_awaiting_client: Awaiting client response
   label_awaiting_manager: Awaiting manager response
@@ -126,8 +137,6 @@ en:
   label_overall_costs: Overall costs
   label_rate: Rate
   label_rate_plural: Rates
-  label_spent_costs: Spent costs
-  label_spent_units: Spent units
   label_status_finished: Finished
   label_status_in_progress: In progress
   label_units: Cost units
@@ -137,6 +146,8 @@ en:
   label_view_all_cost_objects: View all Budgets
   label_yes: "Yes"
   label_hourly_rate: "Hourly rate"
+  label_display_cost_entries: Display unit costs
+  label_display_time_entries: Display reported hours
 
   notice_cost_object_conflict: "Issues must be of the same project."
   notice_no_cost_objects_available: "No budgets available."

--- a/features/view_own_rates.feature
+++ b/features/view_own_rates.feature
@@ -50,8 +50,8 @@ Feature: Permission View Own hourly and cost rates
     And I toggle the Options fieldset
 		And I select to see columns
       | Overall costs  |
-      | Labor Costs    |
-      | Unit Costs     |
+      | Labor costs    |
+      | Unit costs     |
     And I follow "Apply"
     And I wait for AJAX
 		Then I should see "24.00 EUR"

--- a/lib/open_project/costs/patches/issues_helper_patch.rb
+++ b/lib/open_project/costs/patches/issues_helper_patch.rb
@@ -50,7 +50,7 @@ module OpenProject::Costs::Patches::IssuesHelperPatch
                          link_to_cost_object(@issue.cost_object)
                        end
 
-        attributes << [l(:label_cost_object), object_value]
+        attributes << [CostObject.model_name.human, object_value]
 
         if User.current.allowed_to?(:view_time_entries, @project) ||
            User.current.allowed_to?(:view_own_time_entries, @project)
@@ -61,18 +61,18 @@ module OpenProject::Costs::Patches::IssuesHelperPatch
                                                             :issue_id => @issue}) :
                      "-"
 
-           attributes << [l(:label_spent_time), value]
+           attributes << [Issue.human_attribute_name(:spent_hours), value]
         end
 
         unless @overall_costs.nil?
-          attributes << [l(:field_overall_costs), number_to_currency(@overall_costs)]
+          attributes << [Issue.human_attribute_name(:overall_costs), number_to_currency(@overall_costs)]
         end
 
 
         if User.current.allowed_to?(:view_cost_entries, @project) ||
            User.current.allowed_to?(:view_own_cost_entries, @project)
 
-          attributes << [l(:label_spent_units), summarized_cost_entries(@cost_entries)]
+          attributes << [Issue.human_attribute_name(:spent_units), summarized_cost_entries(@cost_entries)]
         end
 
         attributes


### PR DESCRIPTION
I should have spotted most of the translations missing after the core changed it's i18n behaviour. I was however hesitant to delete old translations as I fear that there would be a lot of missing transltions in openproject_reportings if I did.
