### PR TITLE
Remove useless db:migrate:plugins rake task

### DIFF
--- a/lib/tasks/schema.rake
+++ b/lib/tasks/schema.rake
@@ -1,4 +1,0 @@
-namespace :db do
-  desc "dump schema"
-  task(:migrate_plugins) { Rake::Task["db:schema:dump"].invoke }
-end


### PR DESCRIPTION
No idea why this task even was here.
