### PR TITLE
do not double-escape units in reportings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+* `#1020` fix XSS when displaying costs
+
 ## 5.0.1.pre9
 
 * Added missing translations

--- a/lib/open_project/costs/patches/i18n_patch.rb
+++ b/lib/open_project/costs/patches/i18n_patch.rb
@@ -12,8 +12,8 @@ module OpenProject
 
         module InstanceMethods
           def number_to_currency_with_l10n(number, options = {})
-            options_with_default = { unit: Setting.plugin_openproject_costs['costs_currency'],
-                                     format: Setting.plugin_openproject_costs['costs_currency_format'],
+            options_with_default = { unit: h(Setting.plugin_openproject_costs['costs_currency']),
+                                     format: h(Setting.plugin_openproject_costs['costs_currency_format']),
                                      delimiter: l(:currency_delimiter),
                                      separator: l(:currency_separator) }.merge(options)
 

--- a/lib/open_project/costs/patches/i18n_patch.rb
+++ b/lib/open_project/costs/patches/i18n_patch.rb
@@ -12,8 +12,8 @@ module OpenProject
 
         module InstanceMethods
           def number_to_currency_with_l10n(number, options = {})
-            options_with_default = { unit: h(Setting.plugin_openproject_costs['costs_currency']),
-                                     format: h(Setting.plugin_openproject_costs['costs_currency_format']),
+            options_with_default = { unit: ERB::Util.h(Setting.plugin_openproject_costs['costs_currency']),
+                                     format: ERB::Util.h(Setting.plugin_openproject_costs['costs_currency_format']),
                                      delimiter: l(:currency_delimiter),
                                      separator: l(:currency_separator) }.merge(options)
 


### PR DESCRIPTION
Part 1 of "fix xss in reporting when displaying costs"
https://www.openproject.org/issues/1020
