### PR TITLE
17228 spent time is not part of wp in api v3

### DIFF
--- a/lib/open_project/costs/disabled_specs.rb
+++ b/lib/open_project/costs/disabled_specs.rb
@@ -1,4 +1,7 @@
 if Rails.env.test?
   require 'rspec/example_disabler'
   RSpec::ExampleDisabler.disable_example('WorkPackagesController index with valid query settings passed to front-end client visible attributes all attributes visible', 'plugin openproject-costs changes behavior')
+  Rspec::ExampleDisabler.disable_example('API::V3::WorkPackages::WorkPackageRepresenter generation spentTime content time entry with multiple hours', 'plugin openproject-costs changes behavior')
+  Rspec::ExampleDisabler.disable_example('API::V3::WorkPackages::WorkPackageRepresenter generation spentTime content no time entry', 'plugin openproject-costs changes behavior')
+  Rspec::ExampleDisabler.disable_example('API::V3::WorkPackages::WorkPackageRepresenter generation spentTime content time entry with single hour', 'plugin openproject-costs changes behavior')
 end

--- a/lib/open_project/costs/engine.rb
+++ b/lib/open_project/costs/engine.rb
@@ -116,6 +116,12 @@ module OpenProject::Costs
         } if costs_enabled && current_user_allowed_to(:log_costs, represented.model)
       end
 
+      # Overwrite core's spent time property definition
+      #
+      # By setting render_nil to false and returning nil we are able to remove
+      # the spent time property from the work package API response
+      property :spent_time, getter: -> (*) { nil }, render_nil: false
+
       property :cost_object,
                exec_context: :decorator,
                embedded: true,


### PR DESCRIPTION
[`* `#17228` Spent time not part of API V3's work package response`](https://community.openproject.org/work_packages/17228)

https://github.com/opf/openproject/pull/2191
