### PR TITLE
Handle missing summarized cost entries

### DIFF
--- a/app/assets/javascripts/angular/openproject-costs-app.js
+++ b/app/assets/javascripts/angular/openproject-costs-app.js
@@ -35,7 +35,9 @@ openprojectCostsApp.run(['HookService', function(HookService) {
 
     switch (params.type) {
       case "spentUnits":
-        if (params.workPackage.embedded.summarizedCostEntries.length > 0) {
+        var summarizedCostEntries = params.workPackage.embedded.summarizedCostEntries;
+
+        if (summarizedCostEntries && summarizedCostEntries.length > 0) {
           directive = "summarized-cost-entries";
         }
         break;


### PR DESCRIPTION
If costs isn't activated for subprojects the summarized cost entries are
missing in the API response for the current project's work package.
