### PR TITLE
[Foundation] Use the new form style for injected budget field

### DIFF
--- a/app/views/hooks/costs/_view_work_packages_form_details_bottom.html.erb
+++ b/app/views/hooks/costs/_view_work_packages_form_details_bottom.html.erb
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ++#%>
 
 <% if @project && @project.module_enabled?(:costs_module) %>
-  <div class="attribute_wrapper">
+  <div class="form--field">
     <%= form.select :cost_object_id, CostObject.find_all_by_project_id(@project, :order => 'subject ASC').collect { |d| [d.subject, d.id] }, :include_blank => true%>
   </div>
 <% end %>


### PR DESCRIPTION
Fixes a problem where the budget field would not use the correct `form--field` class.

Context: https://community.openproject.org/work_packages/18679
