### PR TITLE
Fix APIv3 specs

### DIFF
--- a/spec/requests/api/cost_entries/cost_entries_by_work_package_resource_spec.rb
+++ b/spec/requests/api/cost_entries/cost_entries_by_work_package_resource_spec.rb
@@ -36,8 +36,12 @@ describe 'API v3 Cost Entry resource' do
   let(:current_user) {
     FactoryGirl.create(:user, member_in_project: project, member_through_role: role)
   }
-  let(:role) { FactoryGirl.create(:role, permissions: permissions) }
-  let(:permissions) { [:view_cost_entries] }
+  let(:role) { FactoryGirl.create(:role, permissions: total_permissions) }
+  let(:total_permissions) {
+    # always include view WP, to ensure accessibility
+    [:view_work_packages] + cost_permissions
+  }
+  let(:cost_permissions) { [:view_cost_entries] }
   let(:project) { FactoryGirl.create(:project) }
   let(:work_package) { FactoryGirl.create(:work_package, project: project) }
   subject(:response) { last_response }
@@ -66,14 +70,14 @@ describe 'API v3 Cost Entry resource' do
     end
 
     context 'user can see own cost entries' do
-      let(:permissions) { [:view_own_cost_entries] }
+      let(:cost_permissions) { [:view_own_cost_entries] }
       it 'should return HTTP 200' do
         expect(response.status).to eql(200)
       end
     end
 
     context 'user has no cost entry permissions' do
-      let(:permissions) { [] }
+      let(:cost_permissions) { [] }
 
       it_behaves_like 'error response',
                       403,
@@ -92,14 +96,14 @@ describe 'API v3 Cost Entry resource' do
     end
 
     context 'user can see own cost entries' do
-      let(:permissions) { [:view_own_cost_entries] }
+      let(:cost_permissions) { [:view_own_cost_entries] }
       it 'should return HTTP 200' do
         expect(response.status).to eql(200)
       end
     end
 
     context 'user has no cost entry permissions' do
-      let(:permissions) { [] }
+      let(:cost_permissions) { [] }
 
       it_behaves_like 'error response',
                       403,


### PR DESCRIPTION
This is part of general house keeping: https://community.openproject.org/work_packages/18714

It fixes wrongfully failing APIv3 integration tests.
The tests did not setup the permissions correctly and ommited access to the work package that was part of the URL (e.g. `/api/v3/work_packages/42/cost_entries`).

Therefore, though the user had access to cost entries in a specific project, he had no access to the WP in question and therefore access to the given URL was denied.
