### PR TITLE
Move cost type administation menu from Module to Administration

### DIFF
--- a/app/controllers/cost_types_controller.rb
+++ b/app/controllers/cost_types_controller.rb
@@ -23,6 +23,7 @@ class CostTypesController < ApplicationController
   # Allow only admins here
   before_filter :require_admin
   before_filter :find_cost_type, :only => [:edit, :update, :set_rate, :toggle_delete]
+  layout 'admin'
 
   helper :sort
   include SortHelper

--- a/lib/open_project/costs/engine.rb
+++ b/lib/open_project/costs/engine.rb
@@ -65,11 +65,11 @@ module OpenProject::Costs
       end
 
       # Menu extensions
-      menu :top_menu,
+      menu :admin_menu,
            :cost_types,
            {:controller => '/cost_types', :action => 'index'},
-           :caption => :cost_types_title,
-           :if => Proc.new { User.current.admin? }
+           :html => { :class => 'icon2 icon-tracker' },
+           :caption => :cost_types_title
 
       menu :project_menu,
            :cost_objects,


### PR DESCRIPTION
This moves the 'cost type' menu from within Modules to
the administration main menu.

You're welcome to suggest another _type_ icon, this will otherwise be the third `icon-tracker` in the Administration main menu.

Related to https://community.openproject.org/work_packages/20503
