### PR TITLE
[21168] Removed a second percent sign on budget page.

### DIFF
--- a/app/views/cost_objects/_list.html.erb
+++ b/app/views/cost_objects/_list.html.erb
@@ -38,7 +38,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <%= content_tag(:td, number_to_currency(cost_object.budget, :precision => 0), :class => 'currency') %>
       <%= content_tag(:td, number_to_currency(cost_object.spent, :precision => 0), :class => 'currency') %>
       <%= content_tag(:td, number_to_currency(cost_object.budget - cost_object.spent, :precision => 0), :class => 'currency') %>
-      <%= content_tag(:td, extended_progress_bar(cost_object.budget_ratio, :legend => "#{cost_object.budget_ratio}%")) %>
+      <%= content_tag(:td, extended_progress_bar(cost_object.budget_ratio, :legend => "#{cost_object.budget_ratio}")) %>
       <%-
         total_budget += cost_object.budget
         labor_budget += cost_object.labor_budget


### PR DESCRIPTION
On the budget page there were two percent signs to show the progress.

https://community.openproject.org/work_packages/21168
