### PR TITLE
[21180] Size of date field on budget page

### DIFF
--- a/app/assets/stylesheets/costs/costs_legacy.css
+++ b/app/assets/stylesheets/costs/costs_legacy.css
@@ -97,9 +97,6 @@ td.comment input {
   cursor: pointer;
 }
 
-#cost_object_fixed_date {
-  width: 10%;
-}
 
 table.progress td.exceeded { background: #E1B9B9 none repeat scroll 0%; }
 

--- a/app/assets/stylesheets/costs/costs_legacy.css
+++ b/app/assets/stylesheets/costs/costs_legacy.css
@@ -97,6 +97,10 @@ td.comment input {
   cursor: pointer;
 }
 
+#cost_object_fixed_date {
+  width: 10%;
+}
+
 table.progress td.exceeded { background: #E1B9B9 none repeat scroll 0%; }
 
 fieldset#group-by table { border-collapse: collapse; }

--- a/app/views/cost_objects/_form.html.erb
+++ b/app/views/cost_objects/_form.html.erb
@@ -27,7 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <%= f.text_area :description, rows: (@cost_object.description.blank? ? 10 : [[10, @cost_object.description.length / 50].max, 100].min), cols: 60 %>
 </div>
 <div class="form--field">
-  <%= f.text_field :fixed_date %>
+  <%= f.text_field :fixed_date, container_class: '-xslim' %>
   <%= calendar_for :cost_object_fixed_date %>
 </div>
 


### PR DESCRIPTION
Resized the date field when updating a budget on the budget page

https://community.openproject.org/work_packages/21180
