### PR TITLE
Indicate summable plugin columns

### DIFF
--- a/lib/open_project/costs/patches/query_patch.rb
+++ b/lib/open_project/costs/patches/query_patch.rb
@@ -37,6 +37,10 @@ module OpenProject::Costs::Patches::QueryPatch
     def xls_value(work_package)
       super_value work_package
     end
+
+    def sum_of(work_packages)
+      work_packages.map { |wp| real_value(wp) }.compact.reduce(:+)
+    end
   end
 
   def self.included(base) # :nodoc:
@@ -47,9 +51,9 @@ module OpenProject::Costs::Patches::QueryPatch
     # Same as typing in the class
     base.class_eval do
       add_available_column(QueryColumn.new(:cost_object_subject))
-      add_available_column(CurrencyQueryColumn.new(:material_costs))
-      add_available_column(CurrencyQueryColumn.new(:labor_costs))
-      add_available_column(CurrencyQueryColumn.new(:overall_costs))
+      add_available_column(CurrencyQueryColumn.new(:material_costs, summable: true))
+      add_available_column(CurrencyQueryColumn.new(:labor_costs, summable: true))
+      add_available_column(CurrencyQueryColumn.new(:overall_costs, summable: true))
 
       Queries::WorkPackages::Filter.add_filter_type_by_field('cost_object_id', 'list_optional')
 

--- a/lib/open_project/costs/patches/query_patch.rb
+++ b/lib/open_project/costs/patches/query_patch.rb
@@ -58,15 +58,6 @@ module OpenProject::Costs::Patches::QueryPatch
   end
 
   module ClassMethods
-    # Setter for +available_columns+ that isn't provided by the core.
-    def available_columns=(v)
-      self.available_columns = (v)
-    end
-
-    # Method to add a column to the +available_columns+ that isn't provided by the core.
-    def add_available_column(column)
-      available_columns << (column)
-    end
   end
 
   module InstanceMethods

--- a/lib/open_project/costs/patches/work_package_patch.rb
+++ b/lib/open_project/costs/patches/work_package_patch.rb
@@ -107,19 +107,11 @@ module OpenProject::Costs::Patches::WorkPackagePatch
     end
 
     def material_costs
-      @material_costs ||= cost_entries.visible_costs(User.current, project).sum("CASE
-        WHEN #{CostEntry.table_name}.overridden_costs IS NULL THEN
-          #{CostEntry.table_name}.costs
-        ELSE
-          #{CostEntry.table_name}.overridden_costs END").to_f
+      CostEntry.costs_of(work_packages: self)
     end
 
     def labor_costs
-      @labor_costs ||= time_entries.visible_costs(User.current, project).sum("CASE
-        WHEN #{TimeEntry.table_name}.overridden_costs IS NULL THEN
-          #{TimeEntry.table_name}.costs
-        ELSE
-          #{TimeEntry.table_name}.overridden_costs END").to_f
+      TimeEntry.costs_of(work_packages: self)
     end
 
     def overall_costs


### PR DESCRIPTION
## OpenProject work package

https://community.openproject.org/work_packages/21447

:warning: merge together with: https://github.com/opf/openproject/pull/3493
## Description

Declares relevant columns added by this plugin as summable.
Also fixes an n+1 query when summing up currency columns (costs columns).
N in this case would be the total number of work packages returned by the query (regardless of pagination).
