### PR TITLE
[21484] Remove existing references to webalys folder in costs

### DIFF
--- a/app/assets/javascripts/costs/editinplace.js
+++ b/app/assets/javascripts/costs/editinplace.js
@@ -48,21 +48,25 @@ function edit(obj, name, obj_value) {
   var value = parsed[0];
   var currency = parsed[1];
 
-  var button = '<span id="'+obj.id+'_cancel" class="form--field-affix -transparent"><input id="'+obj.id+'_cancel" type="image" '+ _cancelButtonAttributes  +' /> </span>';
-  var span = '<span id="'+obj.id+'_editor" class="form--text-field-container">';
+  var form_start = '<section class="form--section" id="'+obj.id+
+                   '_section"><div class="form--field"><div class="form--field-container">';
+  var button = '<div id="'+obj.id+
+               '_cancel" class="form--field-affix -transparent icon icon-close"></div>';
+  var span = '<div id="'+obj.id+'_editor" class="form--text-field-container">';
       span += '<input id="'+obj.id+'_edit" class="form--text-field" name="'+name+'" value="'+value+'" class="currency" type="text" /> ';
-      span += '</span>';
+      span += '</div>';
 
-  var affix = '<span class="form--field-affix" id="'+obj.id+'_affix">' + currency + '</span>';
+  var affix = '<div class="form--field-affix" id="'+obj.id+'_affix">' +
+               currency +
+               '</div>';
+  var form_end = '</div></div></section>';
 
-  new Insertion.After(obj, button + span + affix);
+  new Insertion.After(obj, form_start + button + span + affix + form_end);
 
   Event.observe(obj.id+'_cancel', 'click', function(){cleanUp(obj)});
 }
 
 function cleanUp(obj){
-  Element.remove(obj.id+'_editor');
-  Element.remove(obj.id+'_affix');
-  Element.remove(obj.id+'_cancel');
+  Element.remove(obj.id+'_section');
   Element.show(obj);
 }

--- a/app/views/cost_objects/_edit.html.erb
+++ b/app/views/cost_objects/_edit.html.erb
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                               :url => cost_object_path(@cost_object),
                               :html => {:multipart => true,
                                         :id => 'cost_object_form',
-                                        :class => nil} do |f| %>
+                                        :class => 'form'} do |f| %>
     <%= error_messages_for 'cost_object' %>
     <%= render :partial => 'form', :locals => {:f => f} %>
     <fieldset><legend><%= l(:label_attachment_plural )%></legend>

--- a/app/views/cost_objects/_form.html.erb
+++ b/app/views/cost_objects/_form.html.erb
@@ -192,6 +192,3 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= wikitoolbar_for 'cost_object_description' %>
 
-<% content_for :header_tags do %>
-  <%= javascript_tag "initialize_editinplace('src=\"#{asset_path('webalys/cancel.png')}\" alt=\"#{l(:button_cancel_edit_budget)}\" title=\"#{l(:button_cancel_edit_budget)}\"' )" %>
-<% end %>

--- a/app/views/costlog/edit.html.erb
+++ b/app/views/costlog/edit.html.erb
@@ -102,7 +102,3 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
     <%= styled_button_tag l(:button_save), class: '-with-icon icon-yes' %>
 <% end %>
-
-<% content_for :header_tags do %>
-  <%= javascript_tag "initialize_editinplace('src=\"#{asset_path('webalys/cancel.png')}\" value=\"#{l(:label_cancel)}\" alt=\"#{l(:button_cancel_edit_costs)}\" title=\"#{l(:button_cancel_edit_costs)}\"' )" %>
-<% end %>


### PR DESCRIPTION
This removes the references to the deleted 'webalys'-folder from the code. The images are now displayed as icons.

**Note**: PR https://github.com/opf/openproject/pull/3502 needs to be merged first since it updates the LSG and styles for input affix.

https://community.openproject.org/work_packages/21484
