### PR TITLE
Fix spec 'Delete WP'

### DIFF
--- a/features/work_packages/destroy_with_cost_entries.feature
+++ b/features/work_packages/destroy_with_cost_entries.feature
@@ -54,7 +54,7 @@ Feature: Deleting work packages
 
     When I choose "Reassign"
     And I fill in the id of work package "wp2" into "work package"
-    And I submit the form by the "Apply" button
+    And I submit the form by the "Delete" button
 
     Then I should be on the work packages index page of the project called "ecookbook"
 


### PR DESCRIPTION
Because of https://github.com/opf/openproject/pull/3510 the button on the delete wp site was renamed. This PR fixes the broken spec in the plugin.
