### PR TITLE
[21623] Wrong cells highlighted on hover on budget page

### DIFF
--- a/app/views/cost_objects/_show_variable_cost_object.html.erb
+++ b/app/views/cost_objects/_show_variable_cost_object.html.erb
@@ -22,7 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <div class="grid-block">
   <div class="grid-content">
     <h4><%= VariableCostObject.human_attribute_name(:material_budget) %></h4>
-    <div class="generic-table--container">
+    <div class="generic-table--container -with-footer">
       <div class="generic-table--results-container">
         <table interactive-table role="grid" class="generic-table material_budget_items">
           <colgroup>
@@ -80,18 +80,27 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <td class="currency"><%= material_budget_item.costs_visible_by?(User.current) ? number_to_currency(material_budget_item.costs) : "" %></td>
             </tr>
             <% end %>
-            <% if User.current.allowed_to?(:view_cost_rates, @project) %>
-            <tr><td colspan="4" class="currency"><strong><%= number_to_currency(@cost_object.material_budget) %></strong></td></tr>
-            <% end %>
           </tbody>
+          <% if User.current.allowed_to?(:view_cost_rates, @project) %>
+          <tfoot>
+            <tr>
+              <td class="currency">
+                <div class="generic-table--footer-outer">
+                  <strong><%= number_to_currency(@cost_object.material_budget) %></strong>
+                </div>
+              </td>
+            </tr>
+          </tfoot>
+          <% end %>
         </table>
         <div class="generic-table--header-background"></div>
+        <div class="generic-table--footer-background"></div>
       </div>
     </div>
   </div>
   <div class="grid-content">
     <h4><%= l(:caption_material_costs) %></h4>
-    <div class="generic-table--container">
+    <div class="generic-table--container -with-footer">
       <div class="generic-table--results-container">
         <table interactive-table role="grid" class="generic-table material_budget_items">
           <colgroup>
@@ -164,12 +173,21 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               </tr>
             <% end %>
             <% end %>
-            <% if User.current.allowed_to?(:view_cost_rates, @project) %>
-              <tr><td colspan="4" class="currency"><strong><%= number_to_currency(@cost_object.spent_material) %></strong></td></tr>
-            <% end %>
           </tbody>
+          <% if User.current.allowed_to?(:view_cost_rates, @project) %>
+          <tfoot>
+            <tr>
+              <td class="currency">
+                <div class="generic-table--footer-outer">
+                  <strong><%= number_to_currency(@cost_object.spent_material) %></strong>
+                </div>
+              </td>
+            </tr>
+          </tfoot>
+          <% end %>
         </table>
         <div class="generic-table--header-background"></div>
+        <div class="generic-table--footer-background"></div>
       </div>
     </div>
   </div>
@@ -180,7 +198,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <div class="grid-block">
   <div class="grid-content">
     <h4><%= VariableCostObject.human_attribute_name(:labor_budget)%></h4>
-    <div class="generic-table--container">
+    <div class="generic-table--container -with-footer">
       <div class="generic-table--results-container">
         <table interactive-table role="grid" class="generic-table labor_budget_items">
           <colgroup>
@@ -244,19 +262,28 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <% end %>
             </tr>
             <% end %>
-            <% if User.current.allowed_to?(:view_hourly_rates, @project) || User.current.allowed_to?(:view_own_hourly_rate, @project) %>
-            <tr><td colspan="4" class="currency"><strong><%= number_to_currency(@cost_object.labor_budget) %></strong></td></tr>
-            <% end %>
           </tbody>
+          <% if User.current.allowed_to?(:view_hourly_rates, @project) || User.current.allowed_to?(:view_own_hourly_rate, @project) %>
+          <tfoot>
+            <tr>
+              <td class="currency">
+                <div class="generic-table--footer-outer">
+                  <strong><%= number_to_currency(@cost_object.labor_budget) %></strong>
+                </div>
+              </td>
+            </tr>
+          </tfoot>
+          <% end %>
         </table>
         <div class="generic-table--header-background"></div>
+        <div class="generic-table--footer-background"></div>
       </div>
     </div>
   </div>
 
   <div class="grid-content">
     <h4><%= l(:caption_labor_costs) %></h4>
-    <div class="generic-table--container">
+    <div class="generic-table--container -with-footer">
       <div class="generic-table--results-container">
         <table interactive-table role="grid" class="generic-table labor_budget_items">
           <colgroup>
@@ -330,11 +357,19 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               </tr>
             <% end %>
           <% end %>
-            <tr><td colspan="4" class="currency"><strong><%= number_to_currency(@cost_object.spent_labor) %></strong></td></tr>
-
           </tbody>
+          <tfoot>
+            <tr>
+              <td class="currency">
+                <div class="generic-table--footer-outer">
+                  <strong><%= number_to_currency(@cost_object.spent_labor) %></strong>
+                </div>
+              </td>
+            </tr>
+          </tfoot>
         </table>
         <div class="generic-table--header-background"></div>
+        <div class="generic-table--footer-background"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This introduces the footer element in budget overview tables. This allows the correct layout for the table information and fixes the hover bug.

https://community.openproject.org/work_packages/21623/activity
