### PR TITLE
[21959] Buttons too close on tables (Costs)

### DIFF
--- a/app/assets/stylesheets/costs/costs_legacy.css
+++ b/app/assets/stylesheets/costs/costs_legacy.css
@@ -119,10 +119,6 @@ td.comment input {
   margin: 1rem 1rem 1rem 0.1rem;
 }
 
-.budget-table--add-button{
-  margin-top: 5px;
-}
-
 table.progress td.exceeded { background: #E1B9B9 none repeat scroll 0%; }
 
 fieldset#group-by table { border-collapse: collapse; }

--- a/app/views/cost_objects/_form.html.erb
+++ b/app/views/cost_objects/_form.html.erb
@@ -110,7 +110,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
-  <div style="text-align: right" class="budget-table--add-button"><%= link_to_function l(:button_add_budget_item), "materialBudgetItemsForm.add()", {:class => "icon-context icon-add"} %></div>
+  <div class="generic-table--action-buttons">
+    <%= link_to_function l(:button_add_budget_item), "materialBudgetItemsForm.add()", {class: "button -with-icon icon-context icon-add"} %>
+  </div>
 </fieldset>
 
 <fieldset id="labor_budget_items_fieldset" class="budget-table--fieldset">
@@ -179,7 +181,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
-  <div style="text-align: right" class="budget-table--add-button"><%= link_to_function l(:button_add_budget_item), "laborBudgetItemsForm.add()", {:class => "icon-context icon-add"} %></div>
+  <div class="generic-table--action-buttons">
+    <%= link_to_function l(:button_add_budget_item), "laborBudgetItemsForm.add()", {class: "button -with-icon icon-context icon-add"} %>
+  </div>
 </fieldset>
 
 <%- end %>

--- a/app/views/hourly_rates/edit.html.erb
+++ b/app/views/hourly_rates/edit.html.erb
@@ -80,9 +80,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
-  <div>
+  <div class="generic-table--action-buttons">
     <label class="hidden-for-sighted" for="add_rate_date" %>"><%= l(:description_date_for_new_rate) %></label>
-    <%= link_to_function l(:button_add_rate), "addRate($('add_rate_date'))", {:class => "button icon icon-add"} %>
+    <%= link_to_function l(:button_add_rate), "addRate($('add_rate_date'))", {class: "button -alt-highlight -with-icon icon-add"} %>
+    <%= styled_button_tag l(:button_save), class: '-with-icon icon-yes' %>
   </div>
-  <div><%= styled_button_tag l(:button_save), class: '-with-icon icon-yes' %></div>
 <% end %>


### PR DESCRIPTION
This applies the class 'generic-table--action-buttons' for the correct styling of buttons below tables. Thus it is strongly related to opf/openproject#3756 .

https://community.openproject.org/work_packages/21959/activity
