### PR TITLE
[21965] Icons misaligned in edit budget table

### DIFF
--- a/app/views/cost_objects/_form.html.erb
+++ b/app/views/cost_objects/_form.html.erb
@@ -99,6 +99,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               </th>
             <%end%>
             <th></th>
+            <th class="-short"></th>
           </tr>
         </thead>
         <tbody id="material_budget_items_body">
@@ -167,7 +168,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 </div>
               </th>
             <%end%>
-            <th></th>
+            <th class="-short"></th>
           </tr>
         </thead>
         <tbody id="labor_budget_items_body">

--- a/app/views/cost_objects/_labor_budget_item.html.erb
+++ b/app/views/cost_objects/_labor_budget_item.html.erb
@@ -57,7 +57,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= observe_field( "#{id_prefix}_user_id", :url => {:action => :update_labor_budget_item, :project_id => @project.id}, :with => "'user_id=' + encodeURIComponent(value) + '&hours=' + encodeURIComponent(document.getElementById('#{id_prefix}_hours').value) + '&fixed_date=' + encodeURIComponent(document.getElementById('cost_object_fixed_date').value) + '&element_id=#{id_prefix}'") %>
     <%= observe_field( "#{id_prefix}_hours", :frequency => 1, :url => {:action => :update_labor_budget_item, :project_id => @project.id}, :with => "'user_id=' + encodeURIComponent(document.getElementById('#{id_prefix}_user_id').value) + '&hours=' + encodeURIComponent(value) + '&fixed_date=' + encodeURIComponent(document.getElementById('cost_object_fixed_date').value) + '&element_id=#{id_prefix}'") %>
   </td>
-  <td class="delete budget-table--fields">
+  <td class="delete budget-table--fields buttons -short">
     <%= link_to_function icon_wrapper('icon-context icon-delete',t(:button_delete)), "deleteLaborBudgetItem('#{id_prefix}')", :class => 'no-decoration-on-hover', :title => t(:button_delete) %>
   </td>
 </tr>

--- a/app/views/cost_objects/_material_budget_item.html.erb
+++ b/app/views/cost_objects/_material_budget_item.html.erb
@@ -64,7 +64,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       page << "edit($('#{id_prefix}_costs'), '#{name_prefix}[budget]', '#{number_to_currency(material_budget_item.budget)}');" if material_budget_item.budget
     end %>
   </td>
-  <td class="delete budget-table--fields">
+  <td class="delete budget-table--fields buttons -short">
     <%= link_to_function icon_wrapper('icon-context icon-delete',t(:button_delete)), "deleteMaterialBudgetItem('#{id_prefix}')", :class => 'no-decoration-on-hover', :title => t(:button_delete) %>
   </td>
 </tr>


### PR DESCRIPTION
This uses the classes 'buttons' and '-short'  for the correct styling of the icons on the update budget site.

https://community.openproject.org/work_packages/21965/activity
