### PR TITLE
Define as default module

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,3 @@
+Setting.default_projects_modules += ['costs_module']
+
 OpenProject::Costs::DefaultData.load! unless Rails.env.test?


### PR DESCRIPTION
https://community.openproject.org/work_packages/22020/activity

This does not seem to be ideal by now. For example, there is no check if the seeds are already run. This is out of scope of the pr/work package but affects it as well. 
