### PR TITLE
[22038] Apply new icon styling (Costs)

### DIFF
--- a/app/views/cost_objects/_edit.html.erb
+++ b/app/views/cost_objects/_edit.html.erb
@@ -29,5 +29,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <fieldset><legend><%= l(:label_attachment_plural )%></legend>
       <p><%= render :partial => 'attachments/form' %></p>
     </fieldset>
-    <%= styled_button_tag l(:button_submit), class: '-with-icon icon-yes -highlight', id: 'budget-table--submit-button'%>
+    <%= styled_button_tag l(:button_submit), class: '-with-icon icon-checkmark -highlight', id: 'budget-table--submit-button'%>
 <% end %>

--- a/app/views/cost_objects/new.html.erb
+++ b/app/views/cost_objects/new.html.erb
@@ -29,7 +29,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                               :html => {:multipart => true, :id => 'cost_object_form'} do |f| %>
     <%= error_messages_for 'cost_object' %>
     <%= render :partial => 'form', :locals => {:f => f} %>
-    <%= styled_button_tag l(:button_create), class: '-with-icon icon-yes' %>
+    <%= styled_button_tag l(:button_create), class: '-with-icon icon-checkmark' %>
     <%= styled_button_tag l(:button_create_and_continue), :name => 'continue',
           class: 'button -highlight'%>
 

--- a/app/views/cost_types/_list.html.erb
+++ b/app/views/cost_types/_list.html.erb
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <div class="generic-table--container">
     <div class="generic-table--no-results-container">
       <h2 class="generic-table--no-results-title">
-        <i class="icon-info"></i>
+        <i class="icon-info1"></i>
         <%= l(:label_nothing_display) %>
       </h2>
       <div class="generic-table--no-results-description">
@@ -96,12 +96,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <%= Setting.plugin_openproject_costs['costs_currency'] %>
                   </span>
                   <span class="form-label">
-                    <a href="#" onclick="submitFormWithConfirmation(event, this, false);" class="submit_cost_type"><%= icon_wrapper('icon icon-save1', I18n.t(:caption_save_rate)) %></a>
+                    <a href="#" onclick="submitFormWithConfirmation(event, this, false);" class="submit_cost_type"><%= icon_wrapper('icon icon-save', I18n.t(:caption_save_rate)) %></a>
                   </span>
                 </span>
               <% end %>
             </td>
-            <%= content_tag :td, cost_type.is_default? ? icon_wrapper('icon icon-yes', I18n.t(:general_text_Yes)) : "" %>
+            <%= content_tag :td, cost_type.is_default? ? icon_wrapper('icon icon-checkmark', I18n.t(:general_text_Yes)) : "" %>
             <td>
               <%= form_for cost_type, url:    cost_type_path(cost_type),
                                       method: :delete,

--- a/app/views/cost_types/_list_deleted.html.erb
+++ b/app/views/cost_types/_list_deleted.html.erb
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <div class="generic-table--container">
     <div class="generic-table--no-results-container">
       <h2 class="generic-table--no-results-title">
-        <i class="icon-info"></i>
+        <i class="icon-info1"></i>
         <%= l(:label_nothing_display) %>
       </h2>
       <div class="generic-table--no-results-description">

--- a/app/views/cost_types/edit.html.erb
+++ b/app/views/cost_types/edit.html.erb
@@ -101,7 +101,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= link_to_function l(:button_add_rate), "addRate($('add_rate_date'))", {:class => "button icon icon-add"} %>
   </div>
   <hr class="form--separator">
-  <%= styled_button_tag l(:button_save), class: '-with-icon icon-yes' %>
+  <%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
 <% end %>
 
 

--- a/app/views/cost_types/index.html.erb
+++ b/app/views/cost_types/index.html.erb
@@ -47,7 +47,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                    { :update => "content",
                      :with => "Form.serialize('query_form')",
                      :method => :get
-                   }, :class => 'button -with-icon icon-yes' %>
+                   }, :class => 'button -with-icon icon-checkmark' %>
 
 <%= link_to_remote l(:button_clear),
                    { :url => { :clear_filter => true },

--- a/app/views/costlog/_date_range.html.erb
+++ b/app/views/costlog/_date_range.html.erb
@@ -45,5 +45,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <%= calendar_for :to %>
     </div>
   </div>
-  <%= styled_button_tag l(:button_apply), class: '-with-icon icon-yes' %>
+  <%= styled_button_tag l(:button_apply), class: '-with-icon icon-checkmark' %>
 </fieldset>

--- a/app/views/costlog/edit.html.erb
+++ b/app/views/costlog/edit.html.erb
@@ -100,5 +100,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </div>
     </div>
 
-    <%= styled_button_tag l(:button_save), class: '-with-icon icon-yes' %>
+    <%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
 <% end %>

--- a/app/views/costlog/index.html.erb
+++ b/app/views/costlog/index.html.erb
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%= toolbar title: WorkPackage.human_attribute_name(:spent_costs) do %>
   <% if authorize_for(:costlog, :new) %>
     <%= link_to({:controller => '/costlog', :action => 'new', :work_package_id => @work_package }, class: 'button') do %>
-      <i class="button--icon icon-unit"></i> <%= l(:button_log_costs) %>
+      <i class="button--icon icon-projects"></i> <%= l(:button_log_costs) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/hooks/costs/_view_work_package_show_action_menu.html.erb
+++ b/app/views/hooks/costs/_view_work_package_show_action_menu.html.erb
@@ -20,5 +20,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% if @project && @project.module_enabled?(:costs_module) %>
   <hr />
-  <%= li_unless_nil(link_to_if_authorized l(:button_log_costs), {:controller => '/costlog', :action => 'new', :work_package_id => work_package}, :class => 'icon-context icon-unit') %>
+  <%= li_unless_nil(link_to_if_authorized l(:button_log_costs), {:controller => '/costlog', :action => 'new', :work_package_id => work_package}, :class => 'icon-context icon-projects') %>
 <% end %>

--- a/app/views/hourly_rates/_list_default.html.erb
+++ b/app/views/hourly_rates/_list_default.html.erb
@@ -26,7 +26,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <div class="generic-table--container">
         <div class="generic-table--no-results-container">
           <h2 class="generic-table--no-results-title">
-            <i class="icon-info"></i>
+            <i class="icon-info1"></i>
             <%= l(:label_nothing_display) %>
           </h2>
           <div class="generic-table--no-results-description">
@@ -80,7 +80,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <tr>
             <td style="padding-right: 1em;"><%= rate.valid_from %></td>
             <td class="currency"><%= number_to_currency(rate.rate) %></td>
-            <td><%= rate == current_rate ? icon_wrapper('icon-context icon-yes',I18n.t(:general_text_Yes)) : "" %></td>
+            <td><%= rate == current_rate ? icon_wrapper('icon-context icon-checkmark',I18n.t(:general_text_Yes)) : "" %></td>
           </tr>
         <%- end -%>
         </tbody>

--- a/app/views/hourly_rates/_list_project.html.erb
+++ b/app/views/hourly_rates/_list_project.html.erb
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <div class="generic-table--container">
         <div class="generic-table--no-results-container">
           <h2 class="generic-table--no-results-title">
-            <i class="icon-info"></i>
+            <i class="icon-info1"></i>
             <%= l(:label_nothing_display) %>
           </h2>
           <div class="generic-table--no-results-description">
@@ -89,7 +89,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
           <tr>
             <td style="padding-right: 1em;"><%= rate.valid_from %></td>
             <td class="currency"><%= number_to_currency(rate.rate) %></td>
-            <td><%= rate == current_rate ? icon_wrapper('icon-context icon-yes',I18n.t(:general_text_Yes)) : "" %></td>
+            <td><%= rate == current_rate ? icon_wrapper('icon-context icon-checkmark',I18n.t(:general_text_Yes)) : "" %></td>
           </tr>
         <%- end -%>
         </tbody>

--- a/app/views/hourly_rates/edit.html.erb
+++ b/app/views/hourly_rates/edit.html.erb
@@ -83,6 +83,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <div class="generic-table--action-buttons">
     <label class="hidden-for-sighted" for="add_rate_date" %>"><%= l(:description_date_for_new_rate) %></label>
     <%= link_to_function l(:button_add_rate), "addRate($('add_rate_date'))", {class: "button -alt-highlight -with-icon icon-add"} %>
-    <%= styled_button_tag l(:button_save), class: '-with-icon icon-yes' %>
+    <%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
   </div>
 <% end %>

--- a/frontend/app/openproject-costs-app.js
+++ b/frontend/app/openproject-costs-app.js
@@ -89,7 +89,7 @@ openprojectCostsApp.run(['HookService',
   });
 
   HookService.register('workPackageDetailsMoreMenu', function(params) {
-    return { "log_costs": ["icon-unit"] };
+    return { "log_costs": ["icon-projects"] };
   });
 }]);
 

--- a/lib/open_project/costs/engine.rb
+++ b/lib/open_project/costs/engine.rb
@@ -71,7 +71,7 @@ module OpenProject::Costs
       menu :admin_menu,
            :cost_types,
            { controller: '/cost_types', action: 'index' },
-           html: { class: 'icon2 icon-tracker' },
+           html: { class: 'icon2 icon-types' },
            caption: :label_cost_type_plural
 
       menu :project_menu,


### PR DESCRIPTION
This applies the new icon styling in the plugin. Note that this only works in combination with https://github.com/opf/openproject/pull/3873 since there the icon font is updated.

https://community.openproject.org/work_packages/22038/activity
