### PR TITLE
Remove unused icon class definitions

### DIFF
--- a/app/assets/stylesheets/costs/costs_legacy.css
+++ b/app/assets/stylesheets/costs/costs_legacy.css
@@ -31,10 +31,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   background-position: 20px 40%;
 }
 
-dt > .icon-cost_object:before {
-  content: "\e003";
-}
-
 .filter_values select {
   width: 200px;
 }


### PR DESCRIPTION
This remove obsolete icon definitions. The classes are now defined in the core. This PR belongs to https://github.com/opf/openproject/pull/3967 , where the icons are updated.
