### PR TITLE
[20567] Wrong success message at locking cost types

### DIFF
--- a/app/controllers/cost_types_controller.rb
+++ b/app/controllers/cost_types_controller.rb
@@ -94,7 +94,7 @@ class CostTypesController < ApplicationController
     @cost_type.default = false
 
     if @cost_type.save
-      flash[:notice] = l(:notice_successful_delete)
+      flash[:notice] = l(:notice_successful_lock)
 
       redirect_back_or_default(action: 'index')
     end

--- a/app/views/cost_types/_list.html.erb
+++ b/app/views/cost_types/_list.html.erb
@@ -102,7 +102,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <% end %>
             </td>
             <%= content_tag :td, cost_type.is_default? ? icon_wrapper('icon icon-checkmark', I18n.t(:general_text_Yes)) : "" %>
-            <td>
+            <td class="buttons">
               <%= form_for cost_type, url:    cost_type_path(cost_type),
                                       method: :delete,
                                       html:   { id:    "delete_cost_type_#{cost_type.id}",

--- a/app/views/cost_types/_list_deleted.html.erb
+++ b/app/views/cost_types/_list_deleted.html.erb
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% else %>
   <div class="generic-table--container">
     <div class="generic-table--results-container">
-      <table interactive-table role="grid" class="generic-table deleted_cost_types">
+      <table interactive-table role="grid" class="generic-table locked_cost_types">
         <colgroup>
           <col highlight-col>
           <col highlight-col>

--- a/app/views/cost_types/index.html.erb
+++ b/app/views/cost_types/index.html.erb
@@ -62,6 +62,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%= render :partial => 'list' %>
 
 <% if @include_deleted %>
-  <h3><%= l(:label_deleted_cost_types) %></h3>
+  <h3><%= l(:label_locked_cost_types) %></h3>
   <%= render :partial => 'list_deleted' %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -135,6 +135,7 @@ en:
   label_current_default_rate: "Current default rate"
   label_date_on: "on"
   label_deleted_cost_types: "Deleted cost types"
+  label_locked_cost_types: "Locked cost types"
   label_deliverable: "Budget"
   label_display_cost_entries: "Display unit costs"
   label_display_time_entries: "Display reported hours"
@@ -170,6 +171,7 @@ en:
   notice_no_cost_objects_available: "No budgets available."
   notice_something_wrong: "Something went wrong. Please try again."
   notice_successful_restore: "Successful restore."
+  notice_successful_lock: "Locked successfully."
   notice_cost_logged_successfully: 'Unit cost logged successfully.'
 
   permission_edit_cost_entries: "Edit booked unit costs"

--- a/features/step_definitions/cost_type_steps.rb
+++ b/features/step_definitions/cost_type_steps.rb
@@ -80,7 +80,7 @@ Then(/^the cost type "(.*?)" should be listed as deleted on the index page$/) do
 
   click_link(I18n.t(:button_apply))
 
-  within '.deleted_cost_types' do
+  within '.locked_cost_types' do
     should have_text(name)
   end
 end

--- a/spec/controllers/cost_types_controller_spec.rb
+++ b/spec/controllers/cost_types_controller_spec.rb
@@ -31,7 +31,7 @@ describe CostTypesController, type: :controller do
 
       expect(assigns(:cost_type).deleted_at).to be_a Time
       expect(response).to redirect_to cost_types_path
-      expect(flash[:notice]).to eq I18n.t(:notice_successful_delete)
+      expect(flash[:notice]).to eq I18n.t(:notice_successful_lock)
     end
   end
 


### PR DESCRIPTION
This unifies the use of 'lock' and 'delete' for cost types. The success message after locking a cost type was changed as well as the headline for the locked cost types.

https://community.openproject.org/work_packages/20567/activity
