### PR TITLE
[22063] Revise icons in administration sidebar (cost plugin)

### DIFF
--- a/lib/open_project/costs/engine.rb
+++ b/lib/open_project/costs/engine.rb
@@ -72,7 +72,7 @@ module OpenProject::Costs
       menu :admin_menu,
            :cost_types,
            { controller: '/cost_types', action: 'index' },
-           html: { class: 'icon2 icon-types' },
+           html: { class: 'icon2 icon-cost-types' },
            caption: :label_cost_type_plural
 
       menu :project_menu,


### PR DESCRIPTION
This changes the icon for cost types in the admin sidebar.

https://community.openproject.org/work_packages/22063/activity

The PR for the core update: https://github.com/opf/openproject/pull/4172
