### PR TITLE
Use standard i18n

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ before_install:
   - git init
   - git remote add openproject https://github.com/opf/openproject.git
   - git fetch --depth=1 openproject
-  - git checkout openproject/dev
+  - git checkout openproject/release/5.0
 
   # End of custom plugin instructions.
 

--- a/app/controllers/cost_objects_controller.rb
+++ b/app/controllers/cost_objects_controller.rb
@@ -129,7 +129,7 @@ class CostObjectsController < ApplicationController
       Attachment.attach_files(@cost_object, params[:attachments])
       render_attachment_warning_if_needed(@cost_object)
 
-      flash[:notice] = l(:notice_successful_create)
+      flash[:notice] = t(:notice_successful_create)
       redirect_to(params[:continue] ? { action: 'new' } :
                                       { action: 'show', id: @cost_object })
       return
@@ -158,19 +158,19 @@ class CostObjectsController < ApplicationController
       Attachment.attach_files(@cost_object, params[:attachments])
       render_attachment_warning_if_needed(@cost_object)
 
-      flash[:notice] = l(:notice_successful_update)
+      flash[:notice] = t(:notice_successful_update)
       redirect_to(params[:back_to] || { action: 'show', id: @cost_object })
     else
       render action: 'edit'
     end
   rescue ActiveRecord::StaleObjectError
     # Optimistic locking exception
-    flash.now[:error] = l(:notice_locking_conflict)
+    flash.now[:error] = t(:notice_locking_conflict)
   end
 
   def destroy
     @cost_objects.each(&:destroy)
-    flash[:notice] = l(:notice_successful_delete)
+    flash[:notice] = t(:notice_successful_delete)
     redirect_to action: 'index', project_id: @project
   end
 

--- a/app/controllers/cost_types_controller.rb
+++ b/app/controllers/cost_types_controller.rb
@@ -56,14 +56,14 @@ class CostTypesController < ApplicationController
     @cost_type.attributes = permitted_params.cost_type
 
     if @cost_type.save
-      flash[:notice] = l(:notice_successful_update)
+      flash[:notice] = t(:notice_successful_update)
       redirect_back_or_default(action: 'index')
     else
       render action: 'edit', layout: !request.xhr?
     end
   rescue ActiveRecord::StaleObjectError
     # Optimistic locking exception
-    flash.now[:error] = l(:notice_locking_conflict)
+    flash.now[:error] = t(:notice_locking_conflict)
   end
 
   def new
@@ -78,7 +78,7 @@ class CostTypesController < ApplicationController
     @cost_type = CostType.new(permitted_params.cost_type)
 
     if @cost_type.save
-      flash[:notice] = l(:notice_successful_update)
+      flash[:notice] = t(:notice_successful_update)
       redirect_back_or_default(action: 'index')
     else
       @cost_type.rates.build(valid_from: Date.today) if @cost_type.rates.empty?
@@ -86,7 +86,7 @@ class CostTypesController < ApplicationController
     end
   rescue ActiveRecord::StaleObjectError
     # Optimistic locking exception
-    flash.now[:error] = l(:notice_locking_conflict)
+    flash.now[:error] = t(:notice_locking_conflict)
   end
 
   def destroy
@@ -94,7 +94,7 @@ class CostTypesController < ApplicationController
     @cost_type.default = false
 
     if @cost_type.save
-      flash[:notice] = l(:notice_successful_lock)
+      flash[:notice] = t(:notice_successful_lock)
 
       redirect_back_or_default(action: 'index')
     end
@@ -105,7 +105,7 @@ class CostTypesController < ApplicationController
     @cost_type.default = false
 
     if @cost_type.save
-      flash[:notice] = l(:notice_successful_restore)
+      flash[:notice] = t(:notice_successful_restore)
 
       redirect_back_or_default(action: 'index')
     end
@@ -122,11 +122,11 @@ class CostTypesController < ApplicationController
 
     rate.rate = clean_currency(params[:rate])
     if rate.save
-      flash[:notice] = l(:notice_successful_update)
+      flash[:notice] = t(:notice_successful_update)
       redirect_to action: 'index'
     else
       # FIXME: Do some real error handling here
-      flash[:error] = l(:notice_something_wrong)
+      flash[:error] = t(:notice_something_wrong)
       redirect_to action: 'index'
     end
   end

--- a/app/controllers/costlog_controller.rb
+++ b/app/controllers/costlog_controller.rb
@@ -96,7 +96,7 @@ class CostlogController < ApplicationController
 
     elsif @cost_entry.save
 
-      flash[:notice] = l(:notice_cost_logged_successfully)
+      flash[:notice] = t(:notice_cost_logged_successfully)
       redirect_back_or_default action: 'index', project_id: @cost_entry.project
 
     else
@@ -113,7 +113,7 @@ class CostlogController < ApplicationController
 
     elsif @cost_entry.save
 
-      flash[:notice] = l(:notice_successful_update)
+      flash[:notice] = t(:notice_successful_update)
       redirect_back_or_default action: 'index', project_id: @cost_entry.project
 
     else
@@ -126,7 +126,7 @@ class CostlogController < ApplicationController
     render_404 and return unless @cost_entry
     render_403 and return unless @cost_entry.editable_by?(User.current)
     @cost_entry.destroy
-    flash[:notice] = l(:notice_successful_delete)
+    flash[:notice] = t(:notice_successful_delete)
 
     if request.referer =~ /cost_reports/
       redirect_to controller: '/cost_reports', action: :index

--- a/app/controllers/hourly_rates_controller.rb
+++ b/app/controllers/hourly_rates_controller.rb
@@ -89,7 +89,7 @@ class HourlyRatesController < ApplicationController
     end
 
     if @user.save
-      flash[:notice] = l(:notice_successful_update)
+      flash[:notice] = t(:notice_successful_update)
       if @project.nil?
         redirect_back_or_default(controller: 'users', action: 'edit', id: @user)
       else
@@ -126,7 +126,7 @@ class HourlyRatesController < ApplicationController
           page.replace_html "rate_for_#{@user.id}", link_to(number_to_currency(rate.rate), action: 'edit', id: @user, project_id: @project)
         end
       else
-        flash[:notice] = l(:notice_successful_update)
+        flash[:notice] = t(:notice_successful_update)
         redirect_to action: 'index'
       end
     end

--- a/app/helpers/cost_objects_helper.rb
+++ b/app/helpers/cost_objects_helper.rb
@@ -29,7 +29,7 @@ module CostObjectsHelper
   end
 
   def cost_objects_to_csv(cost_objects)
-    CSV.generate(col_sep: l(:general_csv_separator)) do |csv|
+    CSV.generate(col_sep: t(:general_csv_separator)) do |csv|
       # csv header fields
       headers = ['#',
                  Project.model_name.human,

--- a/app/helpers/costlog_helper.rb
+++ b/app/helpers/costlog_helper.rb
@@ -22,7 +22,7 @@ module CostlogHelper
 
   def render_costlog_breadcrumb
     links = []
-    links << link_to(l(:label_project_all), project_id: nil, work_package_id: nil)
+    links << link_to(t(:label_project_all), project_id: nil, work_package_id: nil)
     links << link_to(h(@project), project_id: @project, work_package_id: nil) if @project
     links << link_to_work_package(@work_package, subject: false) if @work_package
     breadcrumb links
@@ -36,7 +36,7 @@ module CostlogHelper
       cost_types.sort
     end
     collection = []
-    collection << ["--- #{l(:actionview_instancetag_blank_option)} ---", ''] unless cost_types.detect(&:is_default?)
+    collection << ["--- #{t(:actionview_instancetag_blank_option)} ---", ''] unless cost_types.detect(&:is_default?)
     cost_types.each do |t| collection << [t.name, t.id] end
     collection
   end
@@ -65,7 +65,7 @@ module CostlogHelper
     return nil if value.nil? || value == ''
 
     value = value.strip
-    value.gsub!(l(:currency_delimiter), '') if value.include?(l(:currency_delimiter)) && value.include?(l(:currency_separator))
+    value.gsub!(t(:currency_delimiter), '') if value.include?(t(:currency_delimiter)) && value.include?(t(:currency_separator))
     value.gsub(',', '.')
     BigDecimal.new(value)
   end

--- a/app/models/activity/cost_object_activity_provider.rb
+++ b/app/models/activity/cost_object_activity_provider.rb
@@ -33,7 +33,7 @@ class Activity::CostObjectActivityProvider < Activity::BaseActivityProvider
   end
 
   def event_title(event, _activity)
-    "#{l(:label_cost_object)} ##{event['journable_id']}: #{event['cost_object_subject']}"
+    "#{t(:label_cost_object)} ##{event['journable_id']}: #{event['cost_object_subject']}"
   end
 
   def event_path(event, _activity)

--- a/app/models/cost_object.rb
+++ b/app/models/cost_object.rb
@@ -34,7 +34,7 @@ class CostObject < ActiveRecord::Base
   acts_as_journalized
 
   acts_as_event type: 'cost-objects',
-                title: Proc.new { |o| "#{l(:label_cost_object)} ##{o.id}: #{o.subject}" },
+                title: Proc.new { |o| "#{t(:label_cost_object)} ##{o.id}: #{o.subject}" },
                 url: Proc.new { |o| { controller: 'cost_objects', action: 'show', id: o.id } }
 
   validates_presence_of :subject, :project, :author, :kind, :fixed_date
@@ -116,7 +116,7 @@ class CostObject < ActiveRecord::Base
 
   # Label of the current type for display in GUI.  Virtual accessor that is overriden by subclasses.
   def type_label
-    l(:label_cost_object)
+    t(:label_cost_object)
   end
 
   # Amount of the budget spent.  Expressed as as a percentage whole number

--- a/app/models/fixed_cost_object.rb
+++ b/app/models/fixed_cost_object.rb
@@ -20,6 +20,6 @@
 class FixedCostObject < CostObject
   # Label of the current type for display in GUI.
   def type_label
-    l(:label_fixed_cost_object)
+    t(:label_fixed_cost_object)
   end
 end

--- a/app/models/rate.rb
+++ b/app/models/rate.rb
@@ -32,7 +32,7 @@ class Rate < ActiveRecord::Base
   def self.clean_currency(value)
     if value && value.is_a?(String)
       value = value.strip
-      value.gsub!(l(:currency_delimiter), '') if value.include?(l(:currency_delimiter)) && value.include?(l(:currency_separator))
+      value.gsub!(t(:currency_delimiter), '') if value.include?(t(:currency_delimiter)) && value.include?(t(:currency_separator))
       value.gsub(',', '.')
     else
       value

--- a/app/models/variable_cost_object.rb
+++ b/app/models/variable_cost_object.rb
@@ -48,7 +48,7 @@ class VariableCostObject < CostObject
 
   # Label of the current cost_object type for display in GUI.
   def type_label
-    l(:label_variable_cost_object)
+    t(:label_variable_cost_object)
   end
 
   def material_budget

--- a/app/views/cost_objects/_edit.html.erb
+++ b/app/views/cost_objects/_edit.html.erb
@@ -26,8 +26,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                         :class => 'form'} do |f| %>
     <%= error_messages_for 'cost_object' %>
     <%= render :partial => 'form', :locals => {:f => f} %>
-    <fieldset><legend><%= l(:label_attachment_plural )%></legend>
+    <fieldset><legend><%= t(:label_attachment_plural )%></legend>
       <p><%= render :partial => 'attachments/form' %></p>
     </fieldset>
-    <%= styled_button_tag l(:button_submit), class: '-with-icon icon-checkmark -highlight', id: 'budget-table--submit-button'%>
+    <%= styled_button_tag t(:button_submit), class: '-with-icon icon-checkmark -highlight', id: 'budget-table--submit-button'%>
 <% end %>

--- a/app/views/cost_objects/_form.html.erb
+++ b/app/views/cost_objects/_form.html.erb
@@ -120,7 +120,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
   </div>
   <div class="generic-table--action-buttons">
-    <%= link_to_function l(:button_add_budget_item), "materialBudgetItemsForm.add()", {class: "button -alt-highlight -with-icon icon-context icon-add"} %>
+    <%= link_to_function t(:button_add_budget_item), "materialBudgetItemsForm.add()", {class: "button -alt-highlight -with-icon icon-context icon-add"} %>
   </div>
 </fieldset>
 
@@ -191,7 +191,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
   </div>
   <div class="generic-table--action-buttons">
-    <%= link_to_function l(:button_add_budget_item), "laborBudgetItemsForm.add()", {class: "button -alt-highlight -with-icon icon-context icon-add"} %>
+    <%= link_to_function t(:button_add_budget_item), "laborBudgetItemsForm.add()", {class: "button -alt-highlight -with-icon icon-context icon-add"} %>
   </div>
 </fieldset>
 
@@ -200,7 +200,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <div style="clear: both;"> </div>
 
 <% if @cost_object.new_record? %>
-<p><label><%=l(:label_attachment_plural)%></label><%= render :partial => 'attachments/form' %></p>
+<p><label><%=t(:label_attachment_plural)%></label><%= render :partial => 'attachments/form' %></p>
 <% end %>
 
 <%= wikitoolbar_for 'cost_object_description' %>

--- a/app/views/cost_objects/_labor_budget_item.html.erb
+++ b/app/views/cost_objects/_labor_budget_item.html.erb
@@ -39,7 +39,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= cost_form.text_field :hours, :index => id_or_index, :size => 3 %>
   </td>
   <td class="user">
-    <label class="hidden-for-sighted" for="<%= id_prefix %>_user_id"><%= l(:label_user) %></label>
+    <label class="hidden-for-sighted" for="<%= id_prefix %>_user_id"><%= t(:label_user) %></label>
     <%= cost_form.select :user_id, @project.possible_assignees.sort.map{|u| [u.name, u.id]}, {:prompt => true}, {:index => id_or_index, :class => 'form--select'}%>
   </td>
   <td class="comment">
@@ -47,7 +47,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= cost_form.text_field :comments, :index => id_or_index, :size => 40 %>
   </td>
   <td class="currency budget-table--fields">
-    <a href="javascript:;" id="<%= "#{id_prefix}_costs" %>" class="icon-context icon-edit" title="<%= l(:help_click_to_edit) %>">
+    <a href="javascript:;" id="<%= "#{id_prefix}_costs" %>" class="icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
       <%= number_to_currency(labor_budget_item.calculated_costs(@cost_object.fixed_date, @cost_object.project_id)) if labor_budget_item.costs_visible_by?(User.current) %>
     </a>
     <%= update_page_tag do |page|

--- a/app/views/cost_objects/_material_budget_item.html.erb
+++ b/app/views/cost_objects/_material_budget_item.html.erb
@@ -56,7 +56,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= cost_form.text_field :comments, :index => id_or_index, :size => 40 %>
   </td>
   <td class="currency budget-table--fields">
-    <a href="javascript:;" id="<%= "#{id_prefix}_costs" %>" class="icon-context icon-edit" title="<%= l(:help_click_to_edit) %>">
+    <a href="javascript:;" id="<%= "#{id_prefix}_costs" %>" class="icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
       <%= number_to_currency(material_budget_item.calculated_costs(@cost_object.fixed_date)) %>
     </a>
     <%= update_page_tag do |page|

--- a/app/views/cost_objects/_show_variable_cost_object.html.erb
+++ b/app/views/cost_objects/_show_variable_cost_object.html.erb
@@ -18,7 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 
-<h3><%= l(:caption_materials) %></h3>
+<h3><%= t(:caption_materials) %></h3>
 <div class="grid-block">
   <div class="grid-content medium-6">
     <h4><%= VariableCostObject.human_attribute_name(:material_budget) %></h4>
@@ -101,7 +101,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
   </div>
   <div class="grid-content medium-6">
-    <h4><%= l(:caption_material_costs) %></h4>
+    <h4><%= t(:caption_material_costs) %></h4>
     <div>
       <div class="generic-table--container -with-footer">
         <div class="generic-table--results-container">
@@ -195,7 +195,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </div>
 </div>
 
-<h3><%= l(:caption_labor) %></h3>
+<h3><%= t(:caption_labor) %></h3>
 <div class="grid-block">
   <div class="grid-content medium-6">
     <h4><%= VariableCostObject.human_attribute_name(:labor_budget)%></h4>
@@ -284,7 +284,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
   </div>
   <div class="grid-content medium-6">
-    <h4><%= l(:caption_labor_costs) %></h4>
+    <h4><%= t(:caption_labor_costs) %></h4>
     <div>
       <div class="generic-table--container -with-footer">
         <div class="generic-table--results-container">

--- a/app/views/cost_objects/edit.html.erb
+++ b/app/views/cost_objects/edit.html.erb
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title "#{l(:label_edit)} #{l(:label_cost_object_id, id: @cost_object.id)}: #{@cost_object.subject}" %>
-<%= toolbar title: l(:label_cost_object_id, id: @cost_object.id) %>
+<% html_title "#{t(:label_edit)} #{t(:label_cost_object_id, id: @cost_object.id)}: #{@cost_object.subject}" %>
+<%= toolbar title: t(:label_cost_object_id, id: @cost_object.id) %>
 
 <%= render :partial => 'edit' %>
 <%= javascript_tag "Form.Element.focus('cost_object_subject');" %>

--- a/app/views/cost_objects/index.html.erb
+++ b/app/views/cost_objects/index.html.erb
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title(l(:label_cost_object_plural)) %>
-<%= toolbar title: l(:label_cost_object_plural) do %>
+<% html_title(t(:label_cost_object_plural)) %>
+<%= toolbar title: t(:label_cost_object_plural) do %>
   <% if authorize_for(:cost_objects, :new) %>
     <a href="<%= new_projects_cost_object_path(@project) %>" id="add-budget-button" title="Add budget" class="button -alt-highlight">
       <i class="button--icon icon-add"></i>
@@ -31,14 +31,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% end %>
 
 <% if @cost_objects.empty? %>
-<p class="nodata"><%= l(:label_no_data) %></p>
+<p class="nodata"><%= t(:label_no_data) %></p>
 <% else %>
 <%= render :partial => 'list', :locals => {:cost_objects => @cost_objects} %>
 <%= pagination_links_full @cost_objects %>
 <% end %>
 
 <p class="other-formats">
-<%= l(:label_export_to) %>
+<%= t(:label_export_to) %>
 <!--
 <span><%= link_to 'Atom', {:query_id => @query, :format => 'atom', :key => User.current.rss_key}, :class => 'feed' %></span>
 -->

--- a/app/views/cost_objects/new.html.erb
+++ b/app/views/cost_objects/new.html.erb
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title(l(:label_cost_object_new)) %>
-<%= toolbar title: l(:label_cost_object_new) %>
+<% html_title(t(:label_cost_object_new)) %>
+<%= toolbar title: t(:label_cost_object_new) %>
 
 <%= labelled_tabular_form_for @cost_object,
                               :url => projects_cost_objects_path(@project),
@@ -29,8 +29,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                               :html => {:multipart => true, :id => 'cost_object_form'} do |f| %>
     <%= error_messages_for 'cost_object' %>
     <%= render :partial => 'form', :locals => {:f => f} %>
-    <%= styled_button_tag l(:button_create), class: '-with-icon icon-checkmark' %>
-    <%= styled_button_tag l(:button_create_and_continue), :name => 'continue',
+    <%= styled_button_tag t(:button_create), class: '-with-icon icon-checkmark' %>
+    <%= styled_button_tag t(:button_create_and_continue), :name => 'continue',
           class: 'button -highlight'%>
 
     <%= javascript_tag "Form.Element.focus('cost_object_subject');" %>

--- a/app/views/cost_objects/show.html.erb
+++ b/app/views/cost_objects/show.html.erb
@@ -20,26 +20,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title "#{l(:label_cost_object_id, id: @cost_object.id)}: #{@cost_object.subject}" %>
-<%= toolbar title: l(:label_cost_object_id,  id:  @cost_object.id) do %>
+<% html_title "#{t(:label_cost_object_id, id: @cost_object.id)}: #{@cost_object.subject}" %>
+<%= toolbar title: t(:label_cost_object_id,  id:  @cost_object.id) do %>
   <% if authorize_for(:cost_objects, :edit) %>
     <li class="toolbar-item">
       <%= link_to({ controller: 'cost_objects', action: 'edit',  id: @cost_object }, class: 'button', accesskey: accesskey(:edit)) do %>
-        <i class="button--icon icon-edit"></i> <%= l(:button_update) %>
+        <i class="button--icon icon-edit"></i> <%= t(:button_update) %>
       <% end %>
     </li>
   <% end %>
   <% if authorize_for(:cost_objects, :copy) %>
     <li class="toolbar-item">
       <%= link_to({ controller: 'cost_objects', action: 'copy', id: @cost_object }, class: 'button') do %>
-        <i class="button--icon icon-copy"></i> <%= l(:button_copy) %>
+        <i class="button--icon icon-copy"></i> <%= t(:button_copy) %>
       <% end %>
     </li>
   <% end %>
   <% if authorize_for(:cost_objects, :copy) %>
     <li class="toolbar-item">
-      <%= link_to({ controller: 'cost_objects', action: 'destroy', id: @cost_object }, class: 'button', method: :delete, data: { confirm: l(:text_are_you_sure)}) do %>
-        <i class="button--icon icon-delete"></i> <%= l(:button_delete) %>
+      <%= link_to({ controller: 'cost_objects', action: 'destroy', id: @cost_object }, class: 'button', method: :delete, data: { confirm: t(:text_are_you_sure)}) do %>
+        <i class="button--icon icon-delete"></i> <%= t(:button_delete) %>
       <% end %>
     </li>
   <% end %>
@@ -49,7 +49,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   <h3><%=h @cost_object.subject %></h3>
   <p class="author">
     <%= authoring @cost_object.created_on, @cost_object.author %>.
-    <%= l(:label_updated_time, distance_of_time_in_words(Time.now, @cost_object.updated_on)) + '.' if @cost_object.created_on != @cost_object.updated_on %>
+    <%= t(:label_updated_time, distance_of_time_in_words(Time.now, @cost_object.updated_on)) + '.' if @cost_object.created_on != @cost_object.updated_on %>
   </p>
 
   <table class="attributes">
@@ -81,7 +81,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% if authorize_for('cost_objects', 'edit') %>
   <div id="update" style="display:none;">
-  <h3><%= l(:button_update) %></h3>
+  <h3><%= t(:button_update) %></h3>
   <%= render :partial => 'edit' %>
   </div>
 <% end %>

--- a/app/views/cost_types/_list.html.erb
+++ b/app/views/cost_types/_list.html.erb
@@ -25,10 +25,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <div class="generic-table--no-results-container">
       <h2 class="generic-table--no-results-title">
         <i class="icon-info1"></i>
-        <%= l(:label_nothing_display) %>
+        <%= t(:label_nothing_display) %>
       </h2>
       <div class="generic-table--no-results-description">
-        <p class="nodata"><%= l(:label_no_data) %></p>
+        <p class="nodata"><%= t(:label_no_data) %></p>
       </div>
     </div>
   </div>
@@ -63,7 +63,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <div class="generic-table--sort-header-outer">
                 <div class="generic-table--sort-header">
                   <span>
-                    <%= l(:caption_set_rate) %>
+                    <%= t(:caption_set_rate) %>
                   </span>
                 </div>
               </div>
@@ -72,7 +72,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <div class="generic-table--sort-header-outer">
                 <div class="generic-table--sort-header">
                   <span>
-                    <%= l(:caption_default) %>
+                    <%= t(:caption_default) %>
                   </span>
                 </div>
               </div>
@@ -90,7 +90,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <td>
               <%= form_for cost_type, :url => { :controller => '/cost_types', :action => 'set_rate', :id => cost_type }  do |f| %>
                 <span class="inline-label">
-                  <label class="hidden-for-sighted" for="<%= "rate_field_#{cost_type.id}" %>"><%= l(:caption_set_rate) %></label>
+                  <label class="hidden-for-sighted" for="<%= "rate_field_#{cost_type.id}" %>"><%= t(:caption_set_rate) %></label>
                   <%= f.text_field :rate, :value => "", :name => :rate, :size => 7, :id => "rate_field_#{cost_type.id}" %>
                   <span class="form-label">
                     <%= Setting.plugin_openproject_costs['costs_currency'] %>

--- a/app/views/cost_types/_list_deleted.html.erb
+++ b/app/views/cost_types/_list_deleted.html.erb
@@ -25,10 +25,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <div class="generic-table--no-results-container">
       <h2 class="generic-table--no-results-title">
         <i class="icon-info1"></i>
-        <%= l(:label_nothing_display) %>
+        <%= t(:label_nothing_display) %>
       </h2>
       <div class="generic-table--no-results-description">
-        <p class="nodata"><%= l(:label_no_data) %></p>
+        <p class="nodata"><%= t(:label_no_data) %></p>
       </div>
     </div>
   </div>
@@ -62,7 +62,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <div class="generic-table--sort-header-outer">
                 <div class="generic-table--sort-header">
                   <span>
-                    <%= l(:caption_locked_on) %>
+                    <%= t(:caption_locked_on) %>
                   </span>
                 </div>
               </div>

--- a/app/views/cost_types/edit.html.erb
+++ b/app/views/cost_types/edit.html.erb
@@ -20,7 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title l(:label_cost_type_specific, id: @cost_type.id, name: @cost_type.name) %>
+<% html_title t(:label_cost_type_specific, id: @cost_type.id, name: @cost_type.name) %>
 
 <%= toolbar title: CostType.model_name.human %>
 
@@ -41,7 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= f.check_box :default %>
   </div>
 
-  <h3><%= l :caption_rate_history %></h3>
+  <h3><%= t :caption_rate_history %></h3>
   <%= javascript_tag do -%>
     RatesForm = new Subform('<%= escape_javascript(render(:partial => "rate", :object => CostRate.new )) %>',<%= @cost_type.rates.length %>,'rates_body');
   <% end -%>
@@ -97,11 +97,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
   </div>
   <div>
-    <label class="hidden-for-sighted", for="add_rate_date" %>"><%= l(:description_date_for_new_rate) %></label>
-    <%= link_to_function l(:button_add_rate), "addRate($('add_rate_date'))", {:class => "button icon icon-add"} %>
+    <label class="hidden-for-sighted", for="add_rate_date" %>"><%= t(:description_date_for_new_rate) %></label>
+    <%= link_to_function t(:button_add_rate), "addRate($('add_rate_date'))", {:class => "button icon icon-add"} %>
   </div>
   <hr class="form--separator">
-  <%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
+  <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
 <% end %>
 
 

--- a/app/views/cost_types/index.html.erb
+++ b/app/views/cost_types/index.html.erb
@@ -20,36 +20,36 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title l(:label_cost_type_plural) %>
+<% html_title t(:label_cost_type_plural) %>
 <%= toolbar title: CostType.model_name.human(count: 2) do %>
   <li class="toolbar-item">
     <%= link_to new_cost_type_path, class: 'button -alt-highlight' do%>
-      <i class="button--icon icon-add"></i> <%= l(:button_add_cost_type) %>
+      <i class="button--icon icon-add"></i> <%= t(:button_add_cost_type) %>
     <% end %>
   </li>
 <% end %>
 
 <%= styled_form_tag(cost_types_path, { :method => :get, :id => 'query_form' }) do %>
   <fieldset id="filters">
-    <legend><%= l(:label_filter_plural) %></legend>
+    <legend><%= t(:label_filter_plural) %></legend>
     <div class="form--field">
-      <%= styled_label_tag :fixed_date, l(:label_fixed_date) %>
+      <%= styled_label_tag :fixed_date, t(:label_fixed_date) %>
       <%= styled_text_field_tag :fixed_date, @fixed_date %>
       <%= calendar_for :fixed_date %>
     </div>
     <div class="form--field">
-      <%= styled_label_tag :include_deleted, l(:caption_show_locked) %>
+      <%= styled_label_tag :include_deleted, t(:caption_show_locked) %>
       <%= styled_check_box_tag :include_deleted, "1", @include_deleted, :autocomplete => "off" %>
     </div>
   </fieldset>
 <hr class="form--separator">
-<%= link_to_remote l(:button_apply),
+<%= link_to_remote t(:button_apply),
                    { :update => "content",
                      :with => "Form.serialize('query_form')",
                      :method => :get
                    }, :class => 'button -with-icon icon-checkmark' %>
 
-<%= link_to_remote l(:button_clear),
+<%= link_to_remote t(:button_clear),
                    { :url => { :clear_filter => true },
                      :method => :get,
                      :update => "content",
@@ -57,11 +57,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% end %>
 
 <div id="cost_type_flash_notice_outer" style="display:none">
-<div class="flash notice" id="cost_type_flash_notice"><%= l(:notice_successful_update) %></div>
+<div class="flash notice" id="cost_type_flash_notice"><%= t(:notice_successful_update) %></div>
 </div>
 <%= render :partial => 'list' %>
 
 <% if @include_deleted %>
-  <h3><%= l(:label_locked_cost_types) %></h3>
+  <h3><%= t(:label_locked_cost_types) %></h3>
   <%= render :partial => 'list_deleted' %>
 <% end %>

--- a/app/views/costlog/_date_range.html.erb
+++ b/app/views/costlog/_date_range.html.erb
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ++#%>
 
 <fieldset id="filters">
-  <legend><%= l(:label_date_range) %></legend>
+  <legend><%= t(:label_date_range) %></legend>
   <div class="form--field">
     <%= styled_radio_button_tag 'period_type', '1', !@free_period %>
   </div>
@@ -32,18 +32,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <%= styled_radio_button_tag 'period_type', '2', @free_period %>
   </div>
   <div onclick="$('period_type_2').checked = true;">
-    <h4><%= l(:label_date_from) %></h4>
+    <h4><%= t(:label_date_from) %></h4>
     <div class="form--field">
-      <%= styled_label_tag :from, l(:description_date_range_list) %>
+      <%= styled_label_tag :from, t(:description_date_range_list) %>
       <%= styled_text_field_tag :from, @from %>
       <%= calendar_for :from %>
     </div>
-    <h4><%= l(:label_date_to) %></h4>
+    <h4><%= t(:label_date_to) %></h4>
     <div class="form--field">
-      <%= styled_label_tag :to, l(:description_date_range_interval) %>
+      <%= styled_label_tag :to, t(:description_date_range_interval) %>
       <%= styled_text_field_tag :to, @to %>
       <%= calendar_for :to %>
     </div>
   </div>
-  <%= styled_button_tag l(:button_apply), class: '-with-icon icon-checkmark' %>
+  <%= styled_button_tag t(:button_apply), class: '-with-icon icon-checkmark' %>
 </fieldset>

--- a/app/views/costlog/_list.html.erb
+++ b/app/views/costlog/_list.html.erb
@@ -33,7 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </colgroup>
       <thead>
       <tr>
-        <%= sort_header_tag('spent_on', :caption => l(:label_date), :default_order => 'desc') %>
+        <%= sort_header_tag('spent_on', :caption => t(:label_date), :default_order => 'desc') %>
         <%= sort_header_tag('user', :caption => Member.model_name.human) %>
         <%= sort_header_tag('project', :caption => Project.model_name.human )%>
         <%= sort_header_tag('work_package', :caption => WorkPackage.model_name.human, :default_order => 'desc') %>
@@ -46,8 +46,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             </div>
           </div>
         </th>
-        <%= sort_header_tag('units', :caption => l(:label_units)) %>
-        <%= sort_header_tag('costs', :caption => l(:label_overall_costs)) %>
+        <%= sort_header_tag('units', :caption => t(:label_units)) %>
+        <%= sort_header_tag('costs', :caption => t(:label_overall_costs)) %>
         <th></th>
       </tr>
       </thead>
@@ -75,13 +75,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <%= link_to icon_wrapper('icon-context icon-edit',t(:button_edit)),
                         {:controller => '/costlog', :action => 'edit', :id => entry, :project_id => nil},
                         :class => 'no-decoration-on-hover',
-                        :title => l(:button_edit) %>
+                        :title => t(:button_edit) %>
             <%= link_to icon_wrapper('icon-context icon-delete',t(:button_delete)),
                         {:controller => '/costlog', :action => 'destroy', :id => entry, :project_id => nil},
-                        :confirm => l(:text_are_you_sure),
+                        :confirm => t(:text_are_you_sure),
                         :method => :delete,
                         :class => 'no-decoration-on-hover',
-                        :title => l(:button_delete) %>
+                        :title => t(:button_delete) %>
           <% end -%>
         </td>
       </tr>

--- a/app/views/costlog/edit.html.erb
+++ b/app/views/costlog/edit.html.erb
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ++#%>
 
 <%= render partial: 'shared/costs_header' %>
-<h2><%= l(:label_log_costs) %></h2>
+<h2><%= t(:label_log_costs) %></h2>
 
 <% url = @cost_entry.new_record? ?
           { action: 'create', project_id: @project.id } :
@@ -76,7 +76,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <label for="cost_entry_costs_edit" class="form--label"><%= CostEntry.human_attribute_name(:costs) %></label>
         <span class="form--field-container">
           <% if User.current.allowed_to? :view_cost_rates, @cost_entry.project %>
-            <a href="javascript:;" id="cost_entry_costs" class="icon-context icon-edit" title="<%= l(:help_click_to_edit) %>">
+            <a href="javascript:;" id="cost_entry_costs" class="icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
               <%= number_to_currency(@cost_entry.calculated_costs) %>
             </a>
             <%= update_page_tag do |page|
@@ -87,7 +87,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <span id="cost_entry_costs_editor" class="form--text-field-container">
               <input class="currency form--text-field" value="<%= number_to_currency(@cost_entry.overridden_costs, unit: "").strip if @cost_entry.overridden_costs %>" size="7" name="cost_entry[overridden_costs]" id="cost_entry_costs_edit"/> <%= Setting.plugin_openproject_costs['costs_currency'] %>
             </span>
-            <br /><em><%= l(:help_override_rate) %></em>
+            <br /><em><%= t(:help_override_rate) %></em>
           <% end %>
         </span>
       </div>
@@ -97,5 +97,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </div>
     </div>
 
-    <%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
+    <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
 <% end %>

--- a/app/views/costlog/index.html.erb
+++ b/app/views/costlog/index.html.erb
@@ -25,7 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%= toolbar title: WorkPackage.human_attribute_name(:spent_costs) do %>
   <% if authorize_for(:costlog, :new) %>
     <%= link_to({:controller => '/costlog', :action => 'new', :work_package_id => @work_package }, class: 'button') do %>
-      <i class="button--icon icon-projects"></i> <%= l(:button_log_costs) %>
+      <i class="button--icon icon-projects"></i> <%= t(:button_log_costs) %>
     <% end %>
   <% end %>
 <% end %>
@@ -42,7 +42,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <%= pagination_links_full @entries %>
 <% end %>
 
-<% html_title WorkPackage.human_attribute_name(:spent_costs), l(:label_details) %>
+<% html_title WorkPackage.human_attribute_name(:spent_costs), t(:label_details) %>
 
 <% content_for :header_tags do %>
   <%= auto_discovery_link_tag(:atom, {:work_package_id => @work_package, :format => 'atom', :key => User.current.rss_key}, :title => WorkPackage.human_attribute_name(:spent_costs)) %>

--- a/app/views/hooks/costs/_view_work_package_show_action_menu.html.erb
+++ b/app/views/hooks/costs/_view_work_package_show_action_menu.html.erb
@@ -20,5 +20,5 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% if @project && @project.module_enabled?(:costs_module) %>
   <hr />
-  <%= li_unless_nil(link_to_if_authorized l(:button_log_costs), {:controller => '/costlog', :action => 'new', :work_package_id => work_package}, :class => 'icon-context icon-projects') %>
+  <%= li_unless_nil(link_to_if_authorized t(:button_log_costs), {:controller => '/costlog', :action => 'new', :work_package_id => work_package}, :class => 'icon-context icon-projects') %>
 <% end %>

--- a/app/views/hooks/costs/_view_work_packages_bulk_edit_details_bottom.html.erb
+++ b/app/views/hooks/costs/_view_work_packages_bulk_edit_details_bottom.html.erb
@@ -23,8 +23,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <label class="form--label" for='cost_object_id'><%= CostObject.model_name.human %></label>
     <div class="form--field-container">
       <%= styled_select_tag('cost_object_id',
-                            content_tag('option', l(:label_no_change_option), :value => '') +
-                            content_tag('option', l(:label_none), :value => 'none') +
+                            content_tag('option', t(:label_no_change_option), :value => '') +
+                            content_tag('option', t(:label_none), :value => 'none') +
                             options_from_collection_for_select(CostObject.where(project_id: @project.id).order('subject ASC'), :id, :subject))
       %>
     </div>

--- a/app/views/hooks/costs/_view_work_packages_move_bottom.html.erb
+++ b/app/views/hooks/costs/_view_work_packages_move_bottom.html.erb
@@ -21,8 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 <% if @project && @project.module_enabled?(:costs_module) %>
   <div class="form--field">
     <%= styled_label_tag :cost_object_id, CostObject.model_name.human %>
-    <%= styled_select_tag('cost_object_id', (@target_project == @project ? content_tag('option', l(:label_no_change_option), :value => '') : "") +
-                                   content_tag('option', l(:label_none), :value => 'none') +
+    <%= styled_select_tag('cost_object_id', (@target_project == @project ? content_tag('option', t(:label_no_change_option), :value => '') : "") +
+                                   content_tag('option', t(:label_none), :value => 'none') +
                                    options_from_collection_for_select(@target_project.cost_objects, :id, :subject)) %>
   </div>
 <% end %>

--- a/app/views/hourly_rates/_list_default.html.erb
+++ b/app/views/hourly_rates/_list_default.html.erb
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ++#%>
 
 <div class="contextual">
-  <%= link_to l(:button_update), edit_hourly_rate_path(@user), :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
+  <%= link_to t(:button_update), edit_hourly_rate_path(@user), :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
 </div>
 <h3><%= User.human_attribute_name(:default_rates) %></h3>
 <% if @rates_default.blank? %>
@@ -27,10 +27,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <div class="generic-table--no-results-container">
           <h2 class="generic-table--no-results-title">
             <i class="icon-info1"></i>
-            <%= l(:label_nothing_display) %>
+            <%= t(:label_nothing_display) %>
           </h2>
           <div class="generic-table--no-results-description">
-            <p class="nodata"><%= l(:label_no_data) %></p>
+            <p class="nodata"><%= t(:label_no_data) %></p>
           </div>
         </div>
       </div>

--- a/app/views/hourly_rates/_list_project.html.erb
+++ b/app/views/hourly_rates/_list_project.html.erb
@@ -31,7 +31,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <div class="contextual">
   <% if project && User.current.allowed_to?({:controller => '/hourly_rates', :action => 'edit'}, project) %>
-    <%= link_to l(:button_update), {:controller => '/hourly_rates', :action => 'edit', :project_id => project, :id => @user}, :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
+    <%= link_to t(:button_update), {:controller => '/hourly_rates', :action => 'edit', :project_id => project, :id => @user}, :class => 'icon icon-edit', :accesskey => accesskey(:edit) %>
   <% end %>
 </div>
 <h3><%=h project.name %><%= (" - " + number_to_currency(current_rate.rate)) if current_rate %></h3>
@@ -40,10 +40,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <div class="generic-table--no-results-container">
           <h2 class="generic-table--no-results-title">
             <i class="icon-info1"></i>
-            <%= l(:label_nothing_display) %>
+            <%= t(:label_nothing_display) %>
           </h2>
           <div class="generic-table--no-results-description">
-            <p class="nodata"><%= l(:label_no_data) %></p>
+            <p class="nodata"><%= t(:label_no_data) %></p>
           </div>
         </div>
       </div>

--- a/app/views/hourly_rates/edit.html.erb
+++ b/app/views/hourly_rates/edit.html.erb
@@ -20,13 +20,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title l(:label_administration), "#{l(:label_edit)} #{l((@project.nil? ? :caption_default_rate_history_for : :caption_rate_history_for), user: ' ')} #{@user.name}" %>
+<% html_title t(:label_administration), "#{t(:label_edit)} #{l((@project.nil? ? :caption_default_rate_history_for : :caption_rate_history_for), user: ' ')} #{@user.name}" %>
 
-<%= toolbar title: (@project.nil? ? l(:caption_default_rate_history_for, :user => @user.name) :  l(:caption_rate_history_for_project, :user => @user.name, :project => @project.name) ) %>
+<%= toolbar title: (@project.nil? ? t(:caption_default_rate_history_for, :user => @user.name) :  t(:caption_rate_history_for_project, :user => @user.name, :project => @project.name) ) %>
 
 <%- default_rate = @user.current_default_rate -%>
 <% if default_rate%>
-<p><strong><%= l(:label_current_default_rate) %>:</strong> <%= number_to_currency(default_rate.rate)%></p>
+<p><strong><%= t(:label_current_default_rate) %>:</strong> <%= number_to_currency(default_rate.rate)%></p>
 <% end %>
 
 <%= javascript_tag do -%>
@@ -81,8 +81,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     </div>
   </div>
   <div class="generic-table--action-buttons">
-    <label class="hidden-for-sighted" for="add_rate_date" %>"><%= l(:description_date_for_new_rate) %></label>
-    <%= link_to_function l(:button_add_rate), "addRate($('add_rate_date'))", {class: "button -alt-highlight -with-icon icon-add"} %>
-    <%= styled_button_tag l(:button_save), class: '-with-icon icon-checkmark' %>
+    <label class="hidden-for-sighted" for="add_rate_date" %>"><%= t(:description_date_for_new_rate) %></label>
+    <%= link_to_function t(:button_add_rate), "addRate($('add_rate_date'))", {class: "button -alt-highlight -with-icon icon-add"} %>
+    <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
   </div>
 <% end %>

--- a/app/views/hourly_rates/show.html.erb
+++ b/app/views/hourly_rates/show.html.erb
@@ -20,16 +20,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title l(:label_administration), l(:caption_rate_history_for, user: @user.name) %>
+<% html_title t(:label_administration), t(:caption_rate_history_for, user: @user.name) %>
 
-<%= toolbar title: l(:caption_rate_history_for, :user => @user.name) %>
+<%= toolbar title: t(:caption_rate_history_for, :user => @user.name) %>
 
 <% if @project %>
-  <% html_title l(:caption_rate_history_for, user: @user.name) %>
+  <% html_title t(:caption_rate_history_for, user: @user.name) %>
 
   <%= render :partial => 'list_project' %>
 <% else %>
-  <% html_title l(:label_administration), l(:caption_rate_history_for, user: @user.name) %>
+  <% html_title t(:label_administration), t(:caption_rate_history_for, user: @user.name) %>
 
   <%= render :partial => 'list_default' %>
   <%= render :partial => 'list' %>

--- a/app/views/settings/_openproject_costs.html.erb
+++ b/app/views/settings/_openproject_costs.html.erb
@@ -18,11 +18,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 <div class="form--field">
-  <%= styled_label_tag :label_currency, l(:label_currency) %>
+  <%= styled_label_tag :label_currency, t(:label_currency) %>
   <%= styled_text_field_tag 'settings[costs_currency]', @settings['costs_currency'] %>
 </div>
 
 <div class="form--field">
-  <%= styled_label_tag :label_currency_format, l(:label_currency_format) %>
+  <%= styled_label_tag :label_currency_format, t(:label_currency_format) %>
   <%= styled_text_field_tag 'settings[costs_currency_format]', @settings['costs_currency_format'] %>
 </div>

--- a/app/views/users/_rates.html.erb
+++ b/app/views/users/_rates.html.erb
@@ -18,7 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 
-<h2><%= l(:caption_rate_history) %></h2>
+<h2><%= t(:caption_rate_history) %></h2>
 <%
   @rates = HourlyRate.history_for_user(@user)
   @rates_default = @rates.delete(nil)

--- a/lib/open_project/costs/hooks/project_hook.rb
+++ b/lib/open_project/costs/hooks/project_hook.rb
@@ -31,7 +31,7 @@ class OpenProject::Costs::Hooks::ProjectHook < Redmine::Hook::ViewListener
     project = context[:project]
 
     result += content_tag(:th, User.human_attribute_name(:current_rate)) if user.allowed_to?(:view_hourly_rates, project)
-    result += content_tag(:th, l(:caption_set_rate)) if user.allowed_to?(:edit_hourly_rates, project)
+    result += content_tag(:th, t(:caption_set_rate)) if user.allowed_to?(:edit_hourly_rates, project)
 
     result
   end

--- a/lib/open_project/costs/patches/application_helper_patch.rb
+++ b/lib/open_project/costs/patches/application_helper_patch.rb
@@ -25,7 +25,7 @@ module OpenProject::Costs::Patches::ApplicationHelperPatch
         title = nil
         subject = nil
         if options[:subject] == false
-          subject = "#{l(:label_cost_object)} ##{cost_object.id}"
+          subject = "#{t(:label_cost_object)} ##{cost_object.id}"
           title = truncate(cost_object.subject, length: 60)
         else
           subject = cost_object.subject

--- a/lib/open_project/costs/patches/number_helper_patch.rb
+++ b/lib/open_project/costs/patches/number_helper_patch.rb
@@ -30,8 +30,8 @@ module OpenProject::Costs::Patches::NumberHelperPatch
     def number_to_currency_with_l10n(number, options = {})
       options_with_default = { unit: ERB::Util.h(Setting.plugin_openproject_costs['costs_currency']),
                                format: ERB::Util.h(Setting.plugin_openproject_costs['costs_currency_format']),
-                               delimiter: l(:currency_delimiter),
-                               separator: l(:currency_separator) }.merge(options)
+                               delimiter: t(:currency_delimiter),
+                               separator: t(:currency_separator) }.merge(options)
 
       # FIXME: patch ruby instead of this code
       # this circumvents the broken BigDecimal#to_f on Siemens's ruby

--- a/lib/open_project/costs/patches/number_helper_patch.rb
+++ b/lib/open_project/costs/patches/number_helper_patch.rb
@@ -30,8 +30,8 @@ module OpenProject::Costs::Patches::NumberHelperPatch
     def number_to_currency_with_l10n(number, options = {})
       options_with_default = { unit: ERB::Util.h(Setting.plugin_openproject_costs['costs_currency']),
                                format: ERB::Util.h(Setting.plugin_openproject_costs['costs_currency_format']),
-                               delimiter: t(:currency_delimiter),
-                               separator: t(:currency_separator) }.merge(options)
+                               delimiter: I18n.t(:currency_delimiter),
+                               separator: I18n.t(:currency_separator) }.merge(options)
 
       # FIXME: patch ruby instead of this code
       # this circumvents the broken BigDecimal#to_f on Siemens's ruby


### PR DESCRIPTION
Prevents errors such as the following:

```
[31m  Object must be a Date, DateTime or Time object. :label_log_costs given.[0m
      [31m[37mShared Example Group: "assigns" called from [0m[0m
      [31m[37mShared Example Group: "invalid create" called from [0m[0m
      [36m# ...openproject/vendor/bundle/ruby/2.2.0/gems/i18n-0.7.0/lib/i18n/backend/base.rb:53:in `localize'[0m
      [36m# ...openproject/vendor/bundle/ruby/2.2.0/gems/i18n-0.7.0/lib/i18n.rb:247:in `localize'[0m
      [36m# ...openproject/vendor/bundle/ruby/2.2.0/gems/actionview-4.2.5.2/lib/action_view/helpers/translation_helper.rb:88:in `localize'[0m
      [36m# ...openproject/vendor/bundle/ruby/2.2.0/bundler/gems/openproject-costs-02dd8ec5738e/app/views/costlog/edit.html.erb:22:in
```

They really just occur during specs in a certain openproject config. But it's quite silly and confusing to use `l` for this anyway. So I say we fix this.

If everyone agrees that is. And if that is the case we'd have to go through the other plugins and do this, too.
