### PR TITLE
Register costObject as an editable field

### DIFF
--- a/frontend/app/openproject-costs-app.js
+++ b/frontend/app/openproject-costs-app.js
@@ -33,6 +33,14 @@ localeFiles.keys().forEach(function(localeFile) {
   I18n.addTranslations(locale, localeFiles(localeFile)[locale]);
 });
 
+// Register Budget as select inline edit
+angular
+  .module('openproject')
+  .run(['wpEditField', function(wpEditField) {
+    wpEditField.extendFieldType('select', ['Budget']);
+  }]);
+
+
 // main app
 var openprojectCostsApp = angular.module('openproject');
 

--- a/lib/open_project/costs/patches/query_patch.rb
+++ b/lib/open_project/costs/patches/query_patch.rb
@@ -57,7 +57,7 @@ module OpenProject::Costs::Patches::QueryPatch
 
     # Same as typing in the class
     base.class_eval do
-      add_available_column(QueryColumn.new(:cost_object_subject))
+      add_available_column(QueryColumn.new(:cost_object))
 
       add_available_column(CurrencyQueryColumn.new(
                              :material_costs,


### PR DESCRIPTION
Registers `costObject` as a SelectField type

:exclamation:  Depends on https://github.com/opf/openproject/pull/4218
