### PR TITLE
[20566] Saving current rate does not work 

### DIFF
--- a/app/views/cost_types/_list.html.erb
+++ b/app/views/cost_types/_list.html.erb
@@ -88,17 +88,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <%= content_tag :td, cost_type.unit_plural %>
             <%= content_tag :td, to_currency_with_empty(cost_type.rate_at(@fixed_date)), :class => "currency", :id => "cost_type_#{cost_type.id}_rate"%>
             <td>
-              <%= form_for cost_type, :url => { :controller => '/cost_types', :action => 'set_rate', :id => cost_type }  do |f| %>
-                <span class="inline-label">
-                  <label class="hidden-for-sighted" for="<%= "rate_field_#{cost_type.id}" %>"><%= t(:caption_set_rate) %></label>
-                  <%= f.text_field :rate, :value => "", :name => :rate, :size => 7, :id => "rate_field_#{cost_type.id}" %>
-                  <span class="form-label">
-                    <%= Setting.plugin_openproject_costs['costs_currency'] %>
-                  </span>
-                  <span class="form-label">
-                    <a href="#" onclick="submitFormWithConfirmation(event, this, false);" class="submit_cost_type"><%= icon_wrapper('icon icon-save', I18n.t(:caption_save_rate)) %></a>
-                  </span>
+              <%= form_for cost_type, :url => { :controller => '/cost_types', :action => 'set_rate', :id => cost_type }, method: :put, html: { class: 'inline-label' }  do |f| %>
+                <label class="hidden-for-sighted" for="<%= "rate_field_#{cost_type.id}" %>"><%= t(:caption_set_rate) %></label>
+                <%= content_tag :input, '', :value => "", :name => :rate, :size => 7, :id => "rate_field_#{cost_type.id}" %>
+                <span class="form-label">
+                  <%= Setting.plugin_openproject_costs['costs_currency'] %>
                 </span>
+                <a href="#" onclick="submitFormWithConfirmation(event, this, false);" class="submit_cost_type form-label"><%= icon_wrapper('icon icon-save', I18n.t(:caption_save_rate)) %></a>
               <% end %>
             </td>
             <%= content_tag :td, cost_type.is_default? ? icon_wrapper('icon icon-checkmark', I18n.t(:general_text_Yes)) : "" %>


### PR DESCRIPTION
This changes the structure so that the form is the parent element of the save icon and the input fields. Only then does the function submitForm work. Thus the rate can be saved now.

https://community.openproject.org/work_packages/20566/activity
