### PR TITLE
[20421] [Accessibility] Sorting arrows are not pronounced by screen reader (Costs)

### DIFF
--- a/app/views/cost_types/_list.html.erb
+++ b/app/views/cost_types/_list.html.erb
@@ -47,9 +47,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         </colgroup>
         <thead>
           <tr>
-            <%= sort_header_tag "name", :caption => CostType.model_name.human %>
-            <%= sort_header_tag "unit", :caption => CostType.human_attribute_name(:unit) %>
-            <%= sort_header_tag "unit_plural", :caption => CostType.human_attribute_name(:unit_plural) %>
+            <%= sort_header_tag CostType.model_name.human, :caption => CostType.model_name.human %>
+            <%= sort_header_tag CostType.human_attribute_name(:unit), :caption => CostType.human_attribute_name(:unit) %>
+            <%= sort_header_tag CostType.human_attribute_name(:unit_plural), :caption => CostType.human_attribute_name(:unit_plural) %>
             <th>
               <div class="generic-table--sort-header-outer">
                 <div class="generic-table--sort-header">


### PR DESCRIPTION
This sets the correct title for the table header. Thus the screen reader can read the correct translated title.

https://community.openproject.com/work_packages/20421/activity
