### PR TITLE
[20524] [Accessibility] Some pages do not have their own window title (Costs)

### DIFF
--- a/app/views/cost_types/index.html.erb
+++ b/app/views/cost_types/index.html.erb
@@ -20,7 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title t(:label_cost_type_plural) %>
+<% html_title l(:label_administration), t(:label_cost_type_plural) %>
 <%= toolbar title: CostType.model_name.human(count: 2) do %>
   <li class="toolbar-item">
     <%= link_to new_cost_type_path, class: 'button -alt-highlight' do%>

--- a/app/views/costlog/edit.html.erb
+++ b/app/views/costlog/edit.html.erb
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 
+<% html_title t(:label_log_costs) %>
 <%= render partial: 'shared/costs_header' %>
 <h2><%= t(:label_log_costs) %></h2>
 

--- a/app/views/costlog/index.html.erb
+++ b/app/views/costlog/index.html.erb
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 
+<% html_title t(:label_log_costs) %>
 <%= render :partial => 'shared/costs_header' %>
 
 <%= render_costlog_breadcrumb %>

--- a/app/views/settings/_openproject_costs.html.erb
+++ b/app/views/settings/_openproject_costs.html.erb
@@ -17,6 +17,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
+<% html_title l(:label_administration), l(:label_plugins), 'Openproject Costs' %>
 <div class="form--field">
   <%= styled_label_tag :label_currency, t(:label_currency) %>
   <%= styled_text_field_tag 'settings[costs_currency]', @settings['costs_currency'] %>


### PR DESCRIPTION
This inserts concrete html title attributes for some pages. Thus it is easier for blind users to navigate through the application.

https://community.openproject.com/work_packages/20524/activity
