### PR TITLE
[20525] [Accessibility] Some pages do not have a meaningful window title (Costs)

### DIFF
--- a/app/views/cost_types/edit.html.erb
+++ b/app/views/cost_types/edit.html.erb
@@ -20,7 +20,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <%= render :partial => 'shared/costs_header' %>
 
-<% html_title t(:label_cost_type_specific, id: @cost_type.id, name: @cost_type.name) %>
+<% if(@cost_type.id) %>
+  <% html_title  t(:label_cost_type_specific, id: @cost_type.id, name: @cost_type.name) %>
+<% else %>
+  <% html_title l(:label_administration), t(:label_cost_type_plural) %>
+<% end %>
 
 <%= toolbar title: CostType.model_name.human %>
 


### PR DESCRIPTION
This changes the html title of create/edit cost type page. Since the same file is used there must be a differentiation be made for the header title.

Related to https://github.com/opf/openproject/pull/4311

https://community.openproject.com/work_packages/20525/activity
