### PR TITLE
Remove current_user requirement for schema data

### DIFF
--- a/lib/open_project/costs/engine.rb
+++ b/lib/open_project/costs/engine.rb
@@ -213,7 +213,7 @@ module OpenProject::Costs
       schema :spent_time,
              type: 'Duration',
              writable: false,
-             show_if: -> (*) { represented.project.costs_enabled? },
+             show_if: -> (*) { represented.project && represented.project.costs_enabled? },
              required: false
 
       # N.B. in the long term we should have a type like "Currency", but that requires a proper
@@ -222,13 +222,13 @@ module OpenProject::Costs
              type: 'String',
              required: false,
              writable: false,
-             show_if: -> (*) { represented.project.costs_enabled? }
+             show_if: -> (*) { represented.project && represented.project.costs_enabled? }
 
       schema :costs_by_type,
              type: 'Collection',
              name_source: :spent_units,
              required: false,
-             show_if: -> (*) { represented.project.costs_enabled? },
+             show_if: -> (*) { represented.project && represented.project.costs_enabled? },
              writable: false
 
       schema_with_allowed_collection :cost_object,
@@ -242,7 +242,7 @@ module OpenProject::Costs
                                        }
                                      },
                                      show_if: -> (*) {
-                                       represented.project.costs_enabled?
+                                       represented.project && represented.project.costs_enabled?
                                      }
     end
 

--- a/lib/open_project/costs/engine.rb
+++ b/lib/open_project/costs/engine.rb
@@ -213,11 +213,7 @@ module OpenProject::Costs
       schema :spent_time,
              type: 'Duration',
              writable: false,
-             show_if: -> (*) {
-               current_user_allowed_to(:view_time_entries, context: represented.project) ||
-                 (current_user_allowed_to(:view_own_time_entries, context: represented.project) &&
-                     represented.project.costs_enabled?)
-             },
+             show_if: -> (*) { represented.project.costs_enabled? },
              required: false
 
       # N.B. in the long term we should have a type like "Currency", but that requires a proper
@@ -232,12 +228,8 @@ module OpenProject::Costs
              type: 'Collection',
              name_source: :spent_units,
              required: false,
-             writable: false,
-             show_if: -> (*) {
-               represented.project.costs_enabled? &&
-                 (current_user_allowed_to(:view_cost_entries, context: represented.project) ||
-                 current_user_allowed_to(:view_own_cost_entries, context: represented.project))
-             }
+             show_if: -> (*) { represented.project.costs_enabled? },
+             writable: false
 
       schema_with_allowed_collection :cost_object,
                                      type: 'Budget',

--- a/spec/features/users_hourly_rates_spec.rb
+++ b/spec/features/users_hourly_rates_spec.rb
@@ -36,7 +36,7 @@ describe 'hourly rates on user edit', type: :feature, js: true do
     end
 
     it 'shows no data message' do
-      expect(page).to have_text 'No data to display'
+      expect(page).to have_text I18n.t('no_results_title_text')
     end
   end
 
@@ -61,7 +61,7 @@ describe 'hourly rates on user edit', type: :feature, js: true do
       # regression test: clicking save used to result in a error
       it 'leads back to the now empty rate overview' do
         expect(page).to have_text /rate history/i
-        expect(page).to have_text 'No data to display'
+        expect(page).to have_text I18n.t('no_results_title_text')
 
         expect(page).not_to have_text 'Current rate'
       end

--- a/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_schema_representer_spec.rb
@@ -119,7 +119,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
       end
 
       context 'with no time entry permissions' do
-        it_behaves_like 'spentTime not visible'
+        it_behaves_like 'spentTime visible'
       end
 
       context 'with :view_time_entries permission' do
@@ -144,7 +144,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
       context 'with :view_time_entries permission' do
         let(:can_view_time_entries) { true }
-        it_behaves_like 'spentTime visible'
+        it_behaves_like 'spentTime not visible'
       end
 
       context 'with :view_own_time_entries permission' do
@@ -213,7 +213,7 @@ describe ::API::V3::WorkPackages::Schema::WorkPackageSchemaRepresenter do
 
     context 'costs enabled' do
       context 'no permissions' do
-        it_behaves_like 'costsByType not visible'
+        it_behaves_like 'costsByType visible'
       end
 
       context 'can only view own cost entries' do


### PR DESCRIPTION
We don't need to restrict visibility of a schema attribute, since the
work package itself already takes care of that.

Related to https://github.com/opf/openproject/pull/4322

/cc @machisuji 
