### PR TITLE
[23052] Double Breadcrumb in administration (Costs)

### DIFF
--- a/app/views/cost_types/edit.html.erb
+++ b/app/views/cost_types/edit.html.erb
@@ -22,9 +22,12 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 <% if(@cost_type.id) %>
   <% html_title  t(:label_cost_type_specific, id: @cost_type.id, name: @cost_type.name) %>
+  <% local_assigns[:additional_breadcrumb] = @cost_type.name %>
 <% else %>
   <% html_title l(:label_administration), t(:label_cost_type_plural) %>
+  <% local_assigns[:additional_breadcrumb] = l(:label_new) + ' ' + I18n.t('activerecord.models.cost_type.one') %>
 <% end %>
+
 
 <%= toolbar title: CostType.model_name.human %>
 


### PR DESCRIPTION
This changes toolbar and breadcrumb elements in the admin view. The doubled information was removed. 

Core PR: https://github.com/opf/openproject/pull/4370

https://community.openproject.com/work_packages/23052/activity
