### PR TITLE
alter representer cache key based on whether the costs module is activated

### DIFF
--- a/lib/open_project/costs/engine.rb
+++ b/lib/open_project/costs/engine.rb
@@ -246,6 +246,14 @@ module OpenProject::Costs
                                      }
     end
 
+    add_api_representer_cache_key(:v3, :work_packages, :schema, :work_package_schema) do
+      if represented.project.module_enabled?('costs_module')
+        ['costs_enabled']
+      else
+        ['costs_not_enabled']
+      end
+    end
+
     assets %w(costs/costs.css
               costs/costs.js
               work_packages/cost_object.html

--- a/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
+++ b/spec/lib/api/v3/work_packages/work_package_representer_spec.rb
@@ -263,4 +263,29 @@ describe ::API::V3::WorkPackages::WorkPackageRepresenter do
       }).to be_truthy
     end
   end
+
+  describe '#cache_key' do
+    def joined_cache_key
+      representer.cache_key.join('/')
+    end
+
+    before do
+      allow(work_package.project)
+        .to receive(:module_enabled?)
+        .and_return false
+
+      original_cache_key
+    end
+
+    let(:original_cache_key) { joined_cache_key }
+
+    it 'changes depending on whether costs is enabled or not' do
+      allow(work_package.project)
+        .to receive(:module_enabled?)
+        .with('costs_module')
+        .and_return true
+
+      expect(joined_cache_key).to_not eql(original_cache_key)
+    end
+  end
 end


### PR DESCRIPTION
Extends the WP schema cache key with the information of whether the costs plugin is active in the project.

Belongs to https://github.com/opf/openproject/pull/4385
