### PR TITLE
[20449] Remove empty options from required select box

### DIFF
--- a/app/helpers/costlog_helper.rb
+++ b/app/helpers/costlog_helper.rb
@@ -35,17 +35,12 @@ module CostlogHelper
       cost_types << selected_type
       cost_types.sort
     end
-    collection = []
-    collection << ["--- #{t(:actionview_instancetag_blank_option)} ---", ''] unless cost_types.detect(&:is_default?)
-    cost_types.each do |t| collection << [t.name, t.id] end
-    collection
+    cost_types.map { |t| [t.name, t.id] }
   end
 
   def user_collection_for_select_options(_options = {})
     users = @project.possible_assignees
-    collection = []
-    users.each do |u| collection << [u.name, u.id] end
-    collection
+    users.map { |t| [t.name, t.id] }
   end
 
   def extended_progress_bar(pcts, options = {})

--- a/app/views/costlog/edit.html.erb
+++ b/app/views/costlog/edit.html.erb
@@ -46,17 +46,20 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       </div>
       <div class="form--field">
         <%= f.text_field :spent_on, size: 10, required: true %>
+        <label for="cost_entry_spent_on" class="hidden-for-sighted"><%= l(:label_date) %> <%=l(:text_hint_date_format) %></label>
         <%= calendar_for('cost_entry_spent_on') %>
       </div>
       <% if User.current.allowed_to? :log_costs, @project %>
         <div class="form--field">
-          <%= f.select :user_id, user_collection_for_select_options, required: true %>
+        <%# Without knowing why `prompt` is in this case responsible for no blank line in the selection options %>
+          <%= f.select :user_id, user_collection_for_select_options,  required: true, prompt: true, prompt: true %>
         </div>
       <% else %>
         <%= f.hidden_field :user_id, value: User.current.id %>
       <% end %>
       <div class="form--field">
-        <%= f.select :cost_type_id, cost_types_collection_for_select_options, required: true %></p>
+        <%# see above %>
+        <%= f.select :cost_type_id, cost_types_collection_for_select_options, required: true, prompt: true %></p>
       </div>
       <div class="form--field">
         <% if @cost_entry.cost_type.nil? %>


### PR DESCRIPTION
This removes empty options from the select boxes of 'log unit costs' page.

https://community.openproject.com/work_packages/20449/activity
