### PR TITLE
[20428] [Accessibility] Some form fields are not pronounced with their entire label (Costs)

### DIFF
--- a/app/views/costlog/edit.html.erb
+++ b/app/views/costlog/edit.html.erb
@@ -63,14 +63,28 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <%= f.text_field :units, size: 6, required: true %>
         <% else %>
           <% suffix = @cost_entry.units == 1 ? @cost_entry.cost_type.unit : @cost_entry.cost_type.unit_plural %>
-        <%= f.text_field :units,
-                         size: 6,
-                         required: true,
-                         suffix: h(suffix) %>
-          <% end %>
+
+          <label for="cost_entry_units" class="form--label -required">
+            <span aria-hidden="true"><%= Meeting.human_attribute_name(:units) %>
+              <span class="form--label-required" aria-hidden="true">*</span>
+            </span>
+            <span class="hidden-for-sighted"><%= Meeting.human_attribute_name(:units) %>
+              <%= h(suffix) %></span>
+          </label>
+
+          <div class="form--field-container">
+            <%= f.text_field :units,
+                             size: 6,
+                             id: 'cost_entry_units',
+                             no_label: true,
+                             required: true,
+                             suffix: h(suffix) %>
+          </div>
+        <% end %>
           <%= observe_field( "cost_entry_cost_type_id", url: {controller: :cost_objects, action: :update_material_budget_item, project_id: @cost_entry.project}, with: "'cost_type_id=' + encodeURIComponent(value) + '&units=' + encodeURIComponent(document.getElementById('cost_entry_units').value) + '&fixed_date=' + encodeURIComponent(document.getElementById('cost_entry_spent_on').value) + '&element_id=cost_entry'") %>
           <%= observe_field( "cost_entry_units", frequency: 1, url: {controller: :cost_objects, action: :update_material_budget_item, project_id: @cost_entry.project}, with: "'cost_type_id=' + encodeURIComponent(document.getElementById('cost_entry_cost_type_id').value) + '&units=' + encodeURIComponent(value) + '&fixed_date=' + encodeURIComponent(document.getElementById('cost_entry_spent_on').value) + '&element_id=cost_entry'") %>
           <%= observe_field( "cost_entry_spent_on", frequency: 1, url: {controller: :cost_objects, action: :update_material_budget_item, project_id: @cost_entry.project}, with: "'cost_type_id=' + encodeURIComponent(document.getElementById('cost_entry_cost_type_id').value) + '&units=' + encodeURIComponent(document.getElementById('cost_entry_units').value) + '&fixed_date=' + encodeURIComponent(value) + '&element_id=cost_entry'") %>
+
       </div>
 
       <div class="form--field">


### PR DESCRIPTION
This adds a label to the input field 'units' so that is read correctly by the screen reader. 

According core PR: https://github.com/opf/openproject/pull/4487
According meeting PR: https://github.com/finnlabs/openproject-meeting/pull/123

WP: https://community.openproject.com/work_packages/20428/activity
