### PR TITLE
[23057] Fix display of groups in budgets

### DIFF
--- a/app/models/labor_budget_item.rb
+++ b/app/models/labor_budget_item.rb
@@ -20,6 +20,8 @@
 class LaborBudgetItem < ActiveRecord::Base
   belongs_to :cost_object
   belongs_to :user
+  belongs_to :principal, foreign_key: 'user_id'
+
   include ::OpenProject::Costs::DeletedUserFallback
 
   validates_length_of :comments, maximum: 255, allow_nil: true

--- a/app/views/cost_objects/_show_variable_cost_object.html.erb
+++ b/app/views/cost_objects/_show_variable_cost_object.html.erb
@@ -18,8 +18,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 
-<fieldset class="form--fieldset -collapsible collapsed" onclick="toggleFieldset(this);">
-  <legend class="form--fieldset-legend"><%= t(:caption_materials) %></legend>
+<fieldset class="form--fieldset -collapsible collapsed">
+  <legend class="form--fieldset-legend" onclick="toggleFieldset(this);"><%= t(:caption_materials) %></legend>
   <div class="grid-block" style="display:none">
     <div class="grid-content medium-6">
       <h4><%= VariableCostObject.human_attribute_name(:material_budget) %></h4>
@@ -197,8 +197,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </div>
   </fieldset>
 
-<fieldset class="form--fieldset -collapsible collapsed" onclick="toggleFieldset(this);">
-  <legend class="form--fieldset-legend"><%= t(:caption_labor) %></legend>
+<fieldset class="form--fieldset -collapsible collapsed">
+  <legend class="form--fieldset-legend" onclick="toggleFieldset(this);"><%= t(:caption_labor) %></legend>
   <div class="grid-block" style="display:none">
     <div class="grid-content medium-6">
       <h4><%= VariableCostObject.human_attribute_name(:labor_budget)%></h4>
@@ -256,7 +256,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                 <% @cost_object.labor_budget_items.each do |labor_budget_item| %>
                 <tr>
                   <td class="hours"><%= labor_budget_item.hours %>h</td>
-                  <td><%=h labor_budget_item.user.name %></td>
+                  <td><%=h labor_budget_item.principal.name %></td>
                   <td class="comments"><%=h labor_budget_item.comments %></td>
                   <% if labor_budget_item.costs_visible_by?(User.current) %>
                     <td class="currency">

--- a/spec/models/labor_budget_item_spec.rb
+++ b/spec/models/labor_budget_item_spec.rb
@@ -93,6 +93,19 @@ describe LaborBudgetItem, type: :model do
       it { expect(item.user).to eq(user) }
     end
 
+    describe 'WHEN a group is provided' do
+      let(:group) { FactoryGirl.create :group }
+
+      before do
+        item.save!
+        item.reload
+        item.update_attribute(:user_id, group.id)
+        item.reload
+      end
+
+      it { expect(item.principal).to eq(group) }
+    end
+
     describe 'WHEN a non existing user is provided (i.e. the user has been deleted)' do
       before do
         item.save!


### PR DESCRIPTION
Despite groups being available for selection in a budget, its name is
not shown as 'Deleted user'.

https://community.openproject.com/work_packages/23057/activity
