### PR TITLE
[23423] [1j] Ein- und Ausblenden von Seitenbereichen (Budget) mit der Tastatur nicht möglich

### DIFF
--- a/app/views/cost_objects/_show_variable_cost_object.html.erb
+++ b/app/views/cost_objects/_show_variable_cost_object.html.erb
@@ -19,7 +19,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ++#%>
 
 <fieldset class="form--fieldset -collapsible collapsed">
-  <legend class="form--fieldset-legend" onclick="toggleFieldset(this);"><%= t(:caption_materials) %></legend>
+  <legend class="form--fieldset-legend" onclick="toggleFieldset(this);">
+    <a href="javascript:"><%= t(:caption_materials) %></a>
+  </legend>
   <div class="grid-block" style="display:none">
     <div class="grid-content medium-6">
       <h4><%= VariableCostObject.human_attribute_name(:material_budget) %></h4>
@@ -198,7 +200,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
   </fieldset>
 
 <fieldset class="form--fieldset -collapsible collapsed">
-  <legend class="form--fieldset-legend" onclick="toggleFieldset(this);"><%= t(:caption_labor) %></legend>
+  <legend class="form--fieldset-legend" onclick="toggleFieldset(this);">
+    <a href="javascript:"><%= t(:caption_labor) %></a>
+  </legend>
   <div class="grid-block" style="display:none">
     <div class="grid-content medium-6">
       <h4><%= VariableCostObject.human_attribute_name(:labor_budget)%></h4>


### PR DESCRIPTION
This makes the fieldset legends in budget overview focusable. Thus blind users can focus and use them too.

https://community.openproject.com/work_packages/23423/activity
