### PR TITLE
[23450] [8a] Aktuelle Position nicht im Menü gekennzeichnet (Costs)

### DIFF
--- a/app/controllers/hourly_rates_controller.rb
+++ b/app/controllers/hourly_rates_controller.rb
@@ -68,6 +68,11 @@ class HourlyRatesController < ApplicationController
     render action: 'edit', layout: !request.xhr?
   end
 
+  current_menu_item :edit do
+    :cost_objects
+  end
+
+
   def update
     # TODO: copied over from edit
     # remove code where appropriate


### PR DESCRIPTION
This highlights the menu entry 'Budget' when being on the 'hourly rates' page.

Related: 
- https://github.com/opf/openproject/pull/4809
- https://github.com/finnlabs/openproject-meeting/pull/130

https://community.openproject.com/work_packages/23450/activity
