### PR TITLE
hide wp cost attributes if they are empty

### DIFF
--- a/frontend/app/components/wp-display/field-types/wp-display-currency-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-currency-field.module.ts
@@ -1,0 +1,39 @@
+//-- copyright
+// OpenProject is a project management system.
+// Copyright (C) 2012-2014 the OpenProject Foundation (OPF)
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License version 3.
+//
+// OpenProject is a fork of ChiliProject, which is a fork of Redmine. The copyright follows:
+// Copyright (C) 2006-2013 Jean-Philippe Lang
+// Copyright (C) 2010-2013 the ChiliProject Team
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+//
+// See doc/COPYRIGHT.rdoc for more details.
+//++
+
+import {DisplayField} from 'app/components/wp-display/wp-display-field/wp-display-field.module';
+
+export class CurrencyDisplayField extends DisplayField {
+
+  isManualRenderer = true;
+
+  public isEmpty(): boolean {
+    return !this.value ||
+      !parseFloat(this.value.split(" ")[0]);
+  }
+}

--- a/frontend/app/openproject-costs-app.js
+++ b/frontend/app/openproject-costs-app.js
@@ -27,6 +27,7 @@
 //++
 
 var CostsByTypeDisplayField = require('./components/wp-display/field-types/wp-display-costs-by-type-field.module').CostsByTypeDisplayField;
+var CurrencyDisplayField = require('./components/wp-display/field-types/wp-display-currency-field.module').CurrencyDisplayField;
 
 // Register Budget as select inline edit
 angular
@@ -41,6 +42,7 @@ angular
   .run(['wpDisplayField', function(wpDisplayField) {
     wpDisplayField.extendFieldType('resource', ['Budget']);
     wpDisplayField.addFieldType(CostsByTypeDisplayField, 'costs', ['costsByType']);
+    wpDisplayField.addFieldType(CurrencyDisplayField, 'currency', ['laborCosts', 'materialCosts', 'overallCosts']);
   }]);
 
 // main app


### PR DESCRIPTION
With the change in https://github.com/opf/openproject/pull/4824, we can now introduce a custom wp-display-field for currency which has its own empty calculation.

Fixes:

https://community.openproject.com/work_packages/23869/activity
