### PR TITLE
[23431] Change styling of 'add planned costs' button

### DIFF
--- a/app/assets/stylesheets/costs/costs.sass
+++ b/app/assets/stylesheets/costs/costs.sass
@@ -25,3 +25,6 @@
 table.list.members
   .form--text-field.-tiny
     min-width: 60px
+
+.cost_object.details .attributes-key-value--value p
+  margin-bottom: 0

--- a/app/views/cost_objects/_edit.html.erb
+++ b/app/views/cost_objects/_edit.html.erb
@@ -26,9 +26,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                                         :class => 'form'} do |f| %>
     <%= error_messages_for 'cost_object' %>
     <%= render :partial => 'form', :locals => {:f => f} %>
-    <fieldset><legend><%= t(:label_attachment_plural )%></legend>
-      <p><%= render :partial => 'attachments/form' %></p>
-    </fieldset>
   <div class="generic-table--action-buttons">
       <%= styled_button_tag t(:button_submit), class: '-with-icon icon-checkmark -highlight', id: 'budget-table--submit-button'%>
   </div>

--- a/app/views/cost_objects/subform/_labor_budget_subform.html.erb
+++ b/app/views/cost_objects/subform/_labor_budget_subform.html.erb
@@ -92,9 +92,9 @@ end -%>
         <div class="generic-table--header-background"></div>
       </div>
     </div>
-    <div class="generic-table--action-buttons">
-      <a class="budget-add-row button -alt-highlight -with-icon icon-context icon-add">
-        <%= t(:button_add_budget_item) %>
+    <div class="wp-inline-create-button">
+      <a href="javascript:" class="budget-add-row wp-inline-create--add-link" role="link" title="<%= t(:button_add_budget_item) %>">
+        <i class="icon icon-add"></i>
       </a>
     </div>
   </fieldset>

--- a/app/views/cost_objects/subform/_material_budget_subform.html.erb
+++ b/app/views/cost_objects/subform/_material_budget_subform.html.erb
@@ -99,9 +99,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         <div class="generic-table--header-background"></div>
       </div>
     </div>
-    <div class="generic-table--action-buttons">
-      <a href="javascript:" class="budget-add-row button -alt-highlight -with-icon icon-context icon-add">
-        <%= t(:button_add_budget_item) %>
+    <div class="wp-inline-create-button">
+      <a href="javascript:" class="budget-add-row wp-inline-create--add-link" role="link" title="<%= t(:button_add_budget_item) %>">
+        <i class="icon icon-add"></i>
       </a>
     </div>
   </fieldset>

--- a/app/views/cost_types/edit.html.erb
+++ b/app/views/cost_types/edit.html.erb
@@ -102,9 +102,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <div class="generic-table--header-background"></div>
     </div>
   </div>
-  <div class="generic-table--action-buttons">
+  <div class="wp-inline-create-button">
     <label class="hidden-for-sighted" for="add_rate_date" %>"><%= t(:description_date_for_new_rate) %></label>
-    <a id="add_rate_date" href="javascript:" class="add-row-button button -alt-highlight -with-icon icon-add" title="<%= t(:button_add_rate) %>">
+    <a id="add_rate_date" href="javascript:" class="add-row-button wp-inline-create--add-link" title="<%= t(:button_add_rate) %>">
+      <i class="icon icon-add"></i>
       <%= t(:button_add_rate) %>
     </a>
     <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>


### PR DESCRIPTION
This fixes some styling issues on the budget page. Mainly the 'add planned costs' buttons are adapted to the styling of the add button in the WP table.

https://community.openproject.com/work_packages/24341/activity