### PR TITLE
[24397] 'Add rate' column is inconsistent

### DIFF
--- a/app/views/cost_types/edit.html.erb
+++ b/app/views/cost_types/edit.html.erb
@@ -106,7 +106,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <label class="hidden-for-sighted" for="add_rate_date" %>"><%= t(:description_date_for_new_rate) %></label>
     <a id="add_rate_date" href="javascript:" class="add-row-button wp-inline-create--add-link" title="<%= t(:button_add_rate) %>">
       <i class="icon icon-add"></i>
-      <%= t(:button_add_rate) %>
     </a>
     <%= styled_button_tag t(:button_save), class: '-with-icon icon-checkmark' %>
   </div>


### PR DESCRIPTION
This removes inconsistent text from the rate history table. Now the row to add a new line looks like in the WP table and like on the budget pages.

https://community.openproject.com/projects/openproject/work_packages/24397/activity