### PR TITLE
Fix typescript errors

### DIFF
--- a/frontend/app/components/budget/cost-unit-subform.directive.ts
+++ b/frontend/app/components/budget/cost-unit-subform.directive.ts
@@ -46,7 +46,7 @@ export class CostUnitSubformController {
   public makeEditable(id, name){
     var obj = jQuery(id);
 
-    jQuery(id).on('click', this.edit_and_focus(obj, name));
+    jQuery(id).click(this.edit_and_focus(obj, name));
   }
 
   private edit_and_focus(obj, name) {
@@ -56,7 +56,7 @@ export class CostUnitSubformController {
     jQuery('#'+obj[0].id+'_edit').select();
   }
 
-  private edit(obj, name, obj_value) {
+  private edit(obj, name, obj_value?:any) {
     obj.hide();
 
     var obj_value = typeof(obj_value) != 'undefined' ? obj_value : obj[0].innerHTML;

--- a/frontend/app/components/wp-display/field-types/wp-display-costs-by-type-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-costs-by-type-field.module.ts
@@ -28,6 +28,8 @@
 
 import {DisplayField} from 'core-components/wp-display/wp-display-field/wp-display-field.module';
 import {WorkPackageCacheService} from 'core-components/work-packages/work-package-cache.service';
+import {HalResource} from 'core-components/api/api-v3/hal-resources/hal-resource.service.ts';
+import {WorkPackageResource} from 'core-components/api/api-v3/hal-resources/work-package-resource.service.ts';
 
 interface ICostsByType {
   $source: {
@@ -59,8 +61,8 @@ export class CostsByTypeDisplayField extends DisplayField {
     if (this.value && this.value.$loaded === false) {
       this.value.$load().then(() => {
 
-        if (this.resource._type === 'WorkPackage') {
-          this.wpCacheService.updateWorkPackage(this.resource);
+        if (this.resource.$source._type === 'WorkPackage') {
+          this.wpCacheService.updateWorkPackage(<WorkPackageResource> this.resource);
         }
       });
     }

--- a/frontend/app/components/wp-display/field-types/wp-display-currency-field.module.ts
+++ b/frontend/app/components/wp-display/field-types/wp-display-currency-field.module.ts
@@ -26,7 +26,7 @@
 // See doc/COPYRIGHT.rdoc for more details.
 //++
 
-import {DisplayField} from 'components/wp-display/wp-display-field/wp-display-field.module';
+import {DisplayField} from 'core-components/wp-display/wp-display-field/wp-display-field.module';
 
 export class CurrencyDisplayField extends DisplayField {
 


### PR DESCRIPTION
With webpack2, we can finally fix the TS errors in the costs plugin.

Belongs to https://github.com/opf/openproject/pull/5172