### PR TITLE
[24676] Breadcrumb link missing (Costs)

### DIFF
--- a/app/controllers/cost_types_controller.rb
+++ b/app/controllers/cost_types_controller.rb
@@ -140,6 +140,10 @@ class CostTypesController < ApplicationController
   end
 
   def default_breadcrumb
-    CostType.model_name.human(count: 2)
+    if action_name == 'index'
+      CostType.model_name.human(count: 2)
+    else
+      ActionController::Base.helpers.link_to(CostType.model_name.human(count: 2), cost_types_path)
+    end
   end
 end


### PR DESCRIPTION
Similar to https://github.com/opf/openproject/pull/5215 this adds a missing breadcrumb link.

https://community.openproject.com/projects/openproject/work_packages/24676/activity