### PR TITLE
[24899] Hide breadcrumb when not necessary (Costs)

### DIFF
--- a/app/controllers/cost_types_controller.rb
+++ b/app/controllers/cost_types_controller.rb
@@ -142,4 +142,8 @@ class CostTypesController < ApplicationController
   def default_breadcrumb
     CostType.model_name.human(count: 2)
   end
+
+  def show_local_breadcrumb
+    true
+  end
 end


### PR DESCRIPTION
This shows the breadcrumb in the admin page. 

According PRs:
* https://github.com/opf/openproject/pull/5281
* https://github.com/finnlabs/openproject-pdf_export/pull/60
* https://github.com/finnlabs/openproject-zacero/pull/77