### PR TITLE
Fix/update budget item errors

### DIFF
--- a/app/views/cost_objects/_show_variable_cost_object.html.erb
+++ b/app/views/cost_objects/_show_variable_cost_object.html.erb
@@ -88,6 +88,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <% if User.current.allowed_to?(:view_cost_rates, @project) %>
               <tfoot>
                 <tr>
+                  <td colspan="3"></td>
                   <td class="currency">
                     <div class="generic-table--footer-outer">
                       <strong><%= number_to_currency(@cost_object.material_budget) %></strong>
@@ -181,6 +182,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <% if User.current.allowed_to?(:view_cost_rates, @project) %>
               <tfoot>
                 <tr>
+                  <td colspan="3"></td>
                   <td class="currency">
                     <div class="generic-table--footer-outer">
                       <strong><%= number_to_currency(@cost_object.spent_material) %></strong>
@@ -275,6 +277,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               <% if User.current.allowed_to?(:view_hourly_rates, @project) || User.current.allowed_to?(:view_own_hourly_rate, @project) %>
               <tfoot>
                 <tr>
+                  <td colspan="3"></td>
                   <td class="currency">
                     <div class="generic-table--footer-outer">
                       <strong><%= number_to_currency(@cost_object.labor_budget) %></strong>
@@ -370,6 +373,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
               </tbody>
               <tfoot>
                 <tr>
+                  <td colspan="3"></td>
                   <td class="currency">
                     <div class="generic-table--footer-outer">
                       <strong><%= number_to_currency(@cost_object.spent_labor) %></strong>

--- a/app/views/cost_objects/subform/_material_budget_subform.html.erb
+++ b/app/views/cost_objects/subform/_material_budget_subform.html.erb
@@ -18,91 +18,93 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 ++#%>
 
-<%# Build a template object for the frontend to add new rows %>
-<% template_object = @cost_object.material_budget_items.build(cost_type: CostType.default) %>
+<% if CostType.exists? %>
+  <%# Build a template object for the frontend to add new rows %>
+  <% template_object = @cost_object.material_budget_items.build(cost_type: CostType.default) %>
 
-<costs-budget-subform item-count="<%= @cost_object.material_budget_items.length %>"
-                      update-url="<%= url_for(action: :update_material_budget_item, project_id: @project.id) %>">
-  <fieldset id="material_budget_items_fieldset" class="form--fieldset -collapsible">
-    <legend class="form--fieldset-legend" onclick="toggleFieldset(this);"><%= VariableCostObject.human_attribute_name(:material_budget) %></legend>
-      <div class="generic-table--container">
-        <div class="generic-table--results-container">
-          <table class="generic-table" id="material_budget_items">
-            <colgroup>
-              <col highlight-col>
-              <col highlight-col>
-              <col highlight-col>
-              <% if User.current.allowed_to?(:view_cost_rates, @project)%>
+  <costs-budget-subform item-count="<%= @cost_object.material_budget_items.length %>"
+                        update-url="<%= url_for(action: :update_material_budget_item, project_id: @project.id) %>">
+    <fieldset id="material_budget_items_fieldset" class="form--fieldset -collapsible">
+      <legend class="form--fieldset-legend" onclick="toggleFieldset(this);"><%= VariableCostObject.human_attribute_name(:material_budget) %></legend>
+        <div class="generic-table--container">
+          <div class="generic-table--results-container">
+            <table class="generic-table" id="material_budget_items">
+              <colgroup>
                 <col highlight-col>
-              <%end%>
-              <col>
-            </colgroup>
-          <thead>
-            <tr>
-              <th class="cost_units">
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= MaterialBudgetItem.human_attribute_name(:units) %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= CostType.human_attribute_name(:unit) %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= MaterialBudgetItem.human_attribute_name(:cost_type) %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-              <th>
-                <div class="generic-table--sort-header-outer">
-                  <div class="generic-table--sort-header">
-                    <span>
-                      <%= MaterialBudgetItem.human_attribute_name(:comment) %>
-                    </span>
-                  </div>
-                </div>
-              </th>
-              <% if User.current.allowed_to?(:view_cost_rates, @project)%>
-                <th class="currency" id="material_budget_items_price">
+                <col highlight-col>
+                <col highlight-col>
+                <% if User.current.allowed_to?(:view_cost_rates, @project)%>
+                  <col highlight-col>
+                <%end%>
+                <col>
+              </colgroup>
+            <thead>
+              <tr>
+                <th class="cost_units">
                   <div class="generic-table--sort-header-outer">
                     <div class="generic-table--sort-header">
                       <span>
-                        <%= MaterialBudgetItem.human_attribute_name(:budget) %>
+                        <%= MaterialBudgetItem.human_attribute_name(:units) %>
                       </span>
                     </div>
                   </div>
                 </th>
-              <%end%>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody id="material_budget_items_body" class="budget-item-container">
-            <%= render partial: "cost_objects/items/material_budget_item", object: template_object, locals: { templated: true } %>
-            <%- @cost_object.material_budget_items.each_with_index do |material_budget_item, index| -%>
-              <%= render partial: 'cost_objects/items/material_budget_item', object: material_budget_item, locals: {index: index} %>
-            <%- end -%>
-          </tbody>
-        </table>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
+                      <span>
+                        <%= CostType.human_attribute_name(:unit) %>
+                      </span>
+                    </div>
+                  </div>
+                </th>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
+                      <span>
+                        <%= MaterialBudgetItem.human_attribute_name(:cost_type) %>
+                      </span>
+                    </div>
+                  </div>
+                </th>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
+                      <span>
+                        <%= MaterialBudgetItem.human_attribute_name(:comment) %>
+                      </span>
+                    </div>
+                  </div>
+                </th>
+                <% if User.current.allowed_to?(:view_cost_rates, @project)%>
+                  <th class="currency" id="material_budget_items_price">
+                    <div class="generic-table--sort-header-outer">
+                      <div class="generic-table--sort-header">
+                        <span>
+                          <%= MaterialBudgetItem.human_attribute_name(:budget) %>
+                        </span>
+                      </div>
+                    </div>
+                  </th>
+                <%end%>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody id="material_budget_items_body" class="budget-item-container">
+              <%= render partial: "cost_objects/items/material_budget_item", object: template_object, locals: { templated: true } %>
+              <%- @cost_object.material_budget_items.each_with_index do |material_budget_item, index| -%>
+                <%= render partial: 'cost_objects/items/material_budget_item', object: material_budget_item, locals: {index: index} %>
+              <%- end -%>
+            </tbody>
+          </table>
 
+        </div>
       </div>
-    </div>
-    <div class="wp-inline-create-button">
-      <a href="javascript:" class="budget-add-row wp-inline-create--add-link" role="link" title="<%= t(:button_add_budget_item) %>">
-        <%= op_icon('icon icon-add') %>
-      </a>
-    </div>
-  </fieldset>
-</costs-budget-subform>
+      <div class="wp-inline-create-button">
+        <a href="javascript:" class="budget-add-row wp-inline-create--add-link" role="link" title="<%= t(:button_add_budget_item) %>">
+          <%= op_icon('icon icon-add') %>
+        </a>
+      </div>
+    </fieldset>
+  </costs-budget-subform>
+<% end %>

--- a/app/views/cost_objects/update_labor_budget_item.js.erb
+++ b/app/views/cost_objects/update_labor_budget_item.js.erb
@@ -1,5 +1,5 @@
 (function($) {
-  <% if current_user.allowed_to? :view_hourly_rates, @project, for: @user %>
-  $('#<%= "#{@element_id}_costs" %>').html("<%= number_to_currency(@costs) %>");
+  <% if current_user.allowed_to? :view_hourly_rates, @project %>
+    $('#<%= "#{@element_id}_costs" %>').html("<%= number_to_currency(@costs) %>");
   <% end %>
 })(jQuery);

--- a/app/views/cost_objects/update_material_budget_item.js.erb
+++ b/app/views/cost_objects/update_material_budget_item.js.erb
@@ -1,7 +1,7 @@
 (function($) {
   <% if current_user.allowed_to? :view_cost_rates, @project %>
-  $('#<%= "#{@element_id}_costs" %>').html("<%= number_to_currency(@costs) %>");
+    $('#<%= "#{@element_id}_costs" %>').html("<%= number_to_currency(@costs) %>");
   <% end %>
 
-  $('#<%= "#{@element_id}_unit_name" %>').html("<%= h(@units == 1.0 ? @cost_type.unit : @cost_type.unit_plural) %>");
+  $('#<%= "#{@element_id}_unit_name" %>').html("<%= h(@unit) %>");
 })(jQuery);

--- a/frontend/app/components/budget/cost-budget-subform.directive.ts
+++ b/frontend/app/components/budget/cost-budget-subform.directive.ts
@@ -115,7 +115,7 @@ export class CostBudgetSubformController {
     // Augment common values with specific values for this type
     row.find('.budget-item-value').each((_i:number, el:HTMLElement) => {
       var field = angular.element(el);
-      request[field.data('requestKey')] = field.val();
+      request[field.data('requestKey')] = field.val() || '0';
     });
 
     return request;


### PR DESCRIPTION
Should no longer throw the errors documented here:
https://community.openproject.com/projects/openproject/work_packages/25405
https://community.openproject.com/projects/openproject/work_packages/25407

In most error scenarios, the update_(labor/material)_budget_item actions return 0.0 now. 

Additionally, the material budget list is hidden as long as no cost type exists. This might be improved later as it hides functionality, but it is better then producing errors.