### PR TITLE
Fix/overridden budget

### DIFF
--- a/app/views/cost_objects/_show_variable_cost_object.html.erb
+++ b/app/views/cost_objects/_show_variable_cost_object.html.erb
@@ -122,7 +122,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                   <div class="generic-table--sort-header-outer">
                     <div class="generic-table--sort-header">
                       <span>
-                        <%= MaterialBudgetItem.human_attribute_name(:units)%>
+                        <%= MaterialBudgetItem.human_attribute_name(:work_package)%>
+                      </span>
+                    </div>
+                  </div>
+                </th>
+                <th>
+                  <div class="generic-table--sort-header-outer">
+                    <div class="generic-table--sort-header">
+                      <span>
+                        <%= MaterialBudgetItem.human_attribute_name(:units) %>
                       </span>
                     </div>
                   </div>
@@ -132,15 +141,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <div class="generic-table--sort-header">
                       <span>
                         <%= MaterialBudgetItem.human_attribute_name(:cost_type) %>
-                      </span>
-                    </div>
-                  </div>
-                </th>
-                <th>
-                  <div class="generic-table--sort-header-outer">
-                    <div class="generic-table--sort-header">
-                      <span>
-                        <%= MaterialBudgetItem.human_attribute_name(:comment) %>
                       </span>
                     </div>
                   </div>

--- a/app/views/cost_objects/items/_labor_budget_item.html.erb
+++ b/app/views/cost_objects/items/_labor_budget_item.html.erb
@@ -60,11 +60,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
       <label class="hidden-for-sighted" for="<%= id_prefix %>_comments"><%= LaborBudgetItem.human_attribute_name(:comments) %></label>
       <%= cost_form.text_field :comments, index: id_or_index, size: 40 %>
     </td>
-    <td class="currency budget-table--fields">
-      <span id="<%= "#{id_prefix}_costs" %>">
-        <%= number_to_currency(labor_budget_item.calculated_costs(@cost_object.fixed_date, @cost_object.project_id)) if labor_budget_item.costs_visible_by?(User.current) %>
-      </span>
-    </td>
+    <% if User.current.allowed_to?(:view_cost_rates, @project)%>
+      <td class="currency budget-table--fields">
+        <cost-unit-subform obj-id="<%= "#{id_prefix}_costs" %>" obj-name="<%= "#{name_prefix}[budget]" %>">
+          <a href="javascript:;" id="<%= "#{id_prefix}_costs" %>" class="icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
+            <%= number_to_currency(labor_budget_item.budget || labor_budget_item.calculated_costs(@cost_object.fixed_date, @cost_object.project_id)) if labor_budget_item.costs_visible_by?(User.current) %>
+          </a>
+        </cost-unit-subform>
+      </td>
+    <% end %>
     <td class="delete budget-table--fields buttons">
       <a class="delete-budget-item no-decoration-on-hover" title="<%= t(:button_delete) %>" href="javascript:">
         <%= op_icon('icon-context icon-delete') %>

--- a/app/views/cost_objects/items/_material_budget_item.html.erb
+++ b/app/views/cost_objects/items/_material_budget_item.html.erb
@@ -66,11 +66,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
     <label class="hidden-for-sighted" for="<%= id_prefix %>_comments"><%= MaterialBudgetItem.human_attribute_name(:comments) %></label>
     <%= cost_form.text_field :comments, index: id_or_index, size: 40 %>
   </td>
-  <td class="currency budget-table--fields">
-    <span id="<%= "#{id_prefix}_costs" %>">
-      <%= number_to_currency(material_budget_item.calculated_costs(@cost_object.fixed_date)) %>
-    </span>
-  </td>
+  <% if User.current.allowed_to? :view_cost_rates, @project %>
+    <td class="currency budget-table--fields">
+      <cost-unit-subform obj-id="<%= "#{id_prefix}_costs" %>" obj-name="<%= "#{name_prefix}[budget]" %>">
+        <a href="javascript:;" id="<%= "#{id_prefix}_costs" %>" class="icon-context icon-edit" title="<%= t(:help_click_to_edit) %>">
+          <%= number_to_currency(material_budget_item.budget || material_budget_item.calculated_costs(@cost_object.fixed_date)) %>
+        </a>
+      </cost-unit-subform>
+    </td>
+  <% end %>
   <td class="delete budget-table--fields buttons">
     <a class="delete-budget-item no-decoration-on-hover" title="<%= t(:button_delete) %>">
       <%= op_icon('icon-context icon-delete') %>

--- a/frontend/app/components/budget/cost-budget-subform.directive.ts
+++ b/frontend/app/components/budget/cost-budget-subform.directive.ts
@@ -47,7 +47,9 @@ export class CostBudgetSubformController {
 
   constructor(public $element:ng.IAugmentedJQuery,
               public $http:ng.IHttpService,
-              public wpNotificationsService:WorkPackageNotificationService) {
+              public wpNotificationsService:WorkPackageNotificationService,
+              private $scope:ng.IScope,
+              private $compile:any) {
     this.container = $element.find('.budget-item-container');
     this.rowIndex = parseInt(this.itemCount);
 
@@ -91,7 +93,8 @@ export class CostBudgetSubformController {
    * Adds a new empty budget item row with the correct index set
    */
   public addBudgetItem() {
-    this.container.append(this.indexedTemplate);
+    let compiledTemplate = this.$compile(this.indexedTemplate)(this.$scope);
+    this.container.append(compiledTemplate);
     this.rowIndex += 1;
   }
 


### PR DESCRIPTION
Fixes the column headings for the material budget items:

Before:
![image](https://user-images.githubusercontent.com/617519/28117225-ce63f92c-670c-11e7-9cbd-4c44e32b319e.png)


Now:
![image](https://user-images.githubusercontent.com/617519/28117208-bd8b0578-670c-11e7-94c7-c91cd210d52d.png)

And allows overriding the planned costs for material and labor budget items:

![image](https://user-images.githubusercontent.com/617519/28117257-f72f0478-670c-11e7-83d6-3cc8156dac5d.png)

https://community.openproject.com/projects/openproject/work_packages/25737